### PR TITLE
Fix connecting to unleash servers over https

### DIFF
--- a/lib/unleash/client.rb
+++ b/lib/unleash/client.rb
@@ -61,6 +61,7 @@ module Unleash
 
       uri = URI(Unleash.configuration.client_register_url)
       http = Net::HTTP.new(uri.host, uri.port)
+      http.use_ssl = true if uri.scheme == 'https'
       http.open_timeout = Unleash.configuration.timeout # in seconds
       http.read_timeout = Unleash.configuration.timeout # in seconds
       headers = {'Content-Type' => 'application/json'}

--- a/lib/unleash/metrics_reporter.rb
+++ b/lib/unleash/metrics_reporter.rb
@@ -40,6 +40,7 @@ module Unleash
 
       uri = URI(Unleash.configuration.client_metrics_url)
       http = Net::HTTP.new(uri.host, uri.port)
+      http.use_ssl = true if uri.scheme == 'https'
       http.open_timeout = Unleash.configuration.timeout # in seconds
       http.read_timeout = Unleash.configuration.timeout # in seconds
       headers = {'Content-Type' => 'application/json'}

--- a/lib/unleash/toggle_fetcher.rb
+++ b/lib/unleash/toggle_fetcher.rb
@@ -45,6 +45,7 @@ module Unleash
 
       uri = URI(Unleash.configuration.fetch_toggles_url)
       http = Net::HTTP.new(uri.host, uri.port)
+      http.use_ssl = true if uri.scheme == 'https'
       http.open_timeout = Unleash.configuration.timeout # in seconds
       http.read_timeout = Unleash.configuration.timeout # in seconds
       request = Net::HTTP::Get.new(uri.request_uri)


### PR DESCRIPTION
Prior to this change connecting to an unleash server over https would result in an exception.