### PR TITLE
Add option/support for making this unleash client completely dummy.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,12 @@
 sudo: false
 language: ruby
 rvm:
-  - 2.2
   - 2.3
   - 2.4
   - 2.5
+  - 2.6
   - jruby
 before_install:
-  - gem install bundler -v 1.14.6
+  - gem install bundler -v 2.0.1
   # install client spec from official repository:
   - git clone --depth 5 https://github.com/Unleash/client-specification.git client-specification

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Argument | Description | Required? |  Type |  Default Value|
 `instance_id` | Identifier for the running instance of program. Important so you can trace back to where metrics are being collected from. **Highly recommended be be set.** | N | String | random UUID |
 `refresh_interval` | How often the unleash client should check with the server for configuration changes. | N | Integer |  15 |
 `metrics_interval` | How often the unleash client should send metrics to server. | N | Integer | 10 |
-`disable_client` | Disables all communication with the Unleash server. Defeats the entire purpose of using unleash, but can be useful in when running tests. | N | Boolean | F |
+`disable_client` | Disables all communication with the Unleash server. If set, `is_enabled?` will always answer with the `default_value` and configuration validation is skipped. Defeats the entire purpose of using unleash, but can be useful in when running tests. | N | Boolean | F |
 `disable_metrics` | Disables sending metrics to Unleash server. | N | Boolean | F |
 `custom_http_headers` | Custom headers to send to Unleash. | N | Hash | {} |
 `timeout` | How long to wait for the connection to be established or wait in reading state (open_timeout/read_timeout) | N | Integer | 30 |
@@ -94,6 +94,7 @@ Unleash.configure do |config|
   config.url      = 'http://unleash.herokuapp.com/api'
   config.app_name = Rails.application.class.parent.to_s
   # config.instance_id = "#{Socket.gethostname}"
+  config.logger   = Rails.logger
 end
 
 UNLEASH = Unleash::Client.new
@@ -156,6 +157,14 @@ or if client is set in `Rails.configuration.unleash`:
 ```ruby
 if Rails.configuration.unleash.is_enabled? "AwesomeFeature", @unleash_context
   puts "AwesomeFeature is enabled"
+end
+```
+
+If the feature is not found in the server, it will by default return false. However you can override that by setting the default return value to `true`:
+
+```ruby
+if UNLEASH.is_enabled? "AwesomeFeature", @unleash_context, true
+  puts "AwesomeFeature is enabled by default"
 end
 ```
 

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ Argument | Description | Required? |  Type |  Default Value|
 `instance_id` | Identifier for the running instance of program. Important so you can trace back to where metrics are being collected from. **Highly recommended be be set.** | N | String | random UUID |
 `refresh_interval` | How often the unleash client should check with the server for configuration changes. | N | Integer |  15 |
 `metrics_interval` | How often the unleash client should send metrics to server. | N | Integer | 10 |
+`disable_client` | Disables all communication with the Unleash server. Defeats the entire purpose of using unleash, but can be useful in when running tests. | N | Boolean | F |
 `disable_metrics` | Disables sending metrics to Unleash server. | N | Boolean | F |
 `custom_http_headers` | Custom headers to send to Unleash. | N | Hash | {} |
 `timeout` | How long to wait for the connection to be established or wait in reading state (open_timeout/read_timeout) | N | Integer | 30 |

--- a/lib/unleash/client.rb
+++ b/lib/unleash/client.rb
@@ -27,13 +27,18 @@ module Unleash
             Unleash.reporter.send
           end
         end
+      else
+        Unleash.logger.warn "Unleash::Client is disabled! Will only return default results!"
       end
     end
 
     def is_enabled?(feature, context = nil, default_value = false)
         Unleash.logger.debug "Unleash::Client.is_enabled? feature: #{feature} with context #{context}"
 
-        return default_value if Unleash.configuration.disable_client
+        if Unleash.configuration.disable_client
+          Unleash.logger.warn "unleash_client is disabled! Always returning #{default_value} for feature #{feature}!"
+          return default_value
+        end
 
         toggle_as_hash = Unleash.toggles.select{ |toggle| toggle['name'] == feature }.first if Unleash.toggles
 

--- a/lib/unleash/client.rb
+++ b/lib/unleash/client.rb
@@ -15,21 +15,25 @@ module Unleash
       Unleash.logger = Unleash.configuration.logger
       Unleash.logger.level = Unleash.configuration.log_level
 
-      Unleash.toggle_fetcher = Unleash::ToggleFetcher.new
-      register
+      unless Unleash.configuration.disable_client
+        Unleash.toggle_fetcher = Unleash::ToggleFetcher.new
+        register
 
-      unless Unleash.configuration.disable_metrics
-        Unleash.toggle_metrics = Unleash::Metrics.new
-        Unleash.reporter = Unleash::MetricsReporter.new
-        scheduledExecutor = Unleash::ScheduledExecutor.new('MetricsReporter', Unleash.configuration.metrics_interval)
-        scheduledExecutor.run do
-          Unleash.reporter.send
+        unless Unleash.configuration.disable_metrics
+          Unleash.toggle_metrics = Unleash::Metrics.new
+          Unleash.reporter = Unleash::MetricsReporter.new
+          scheduledExecutor = Unleash::ScheduledExecutor.new('MetricsReporter', Unleash.configuration.metrics_interval)
+          scheduledExecutor.run do
+            Unleash.reporter.send
+          end
         end
       end
     end
 
     def is_enabled?(feature, context = nil, default_value = false)
         Unleash.logger.debug "Unleash::Client.is_enabled? feature: #{feature} with context #{context}"
+
+        return default_value if Unleash.configuration.disable_client
 
         toggle_as_hash = Unleash.toggles.select{ |toggle| toggle['name'] == feature }.first if Unleash.toggles
 

--- a/lib/unleash/configuration.rb
+++ b/lib/unleash/configuration.rb
@@ -5,6 +5,7 @@ module Unleash
   class Configuration
     attr_accessor :url, :app_name, :instance_id,
       :custom_http_headers,
+      :disable_client,
       :disable_metrics, :timeout, :retry_limit,
       :refresh_interval, :metrics_interval,
       :backup_file, :logger, :log_level
@@ -19,6 +20,7 @@ module Unleash
       else
         raise ArgumentError, "custom_http_headers must be a hash."
       end
+      self.disable_client   = opts[:disable_client]  || false
       self.disable_metrics  = opts[:disable_metrics]  || false
       self.refresh_interval = opts[:refresh_interval] || 15
       self.metrics_interval = opts[:metrics_interval] || 10
@@ -47,6 +49,8 @@ module Unleash
     end
 
     def validate!
+      return if self.disable_client
+
       if self.app_name.nil? or self.url.nil?
         raise ArgumentError, "URL and app_name are required parameters."
       end

--- a/lib/unleash/configuration.rb
+++ b/lib/unleash/configuration.rb
@@ -20,7 +20,7 @@ module Unleash
       else
         raise ArgumentError, "custom_http_headers must be a hash."
       end
-      self.disable_client   = opts[:disable_client]  || false
+      self.disable_client   = opts[:disable_client]   || false
       self.disable_metrics  = opts[:disable_metrics]  || false
       self.refresh_interval = opts[:refresh_interval] || 15
       self.metrics_interval = opts[:metrics_interval] || 10
@@ -30,7 +30,7 @@ module Unleash
       self.backup_file   = opts[:backup_file] || nil
 
       self.logger    = opts[:logger] || Logger.new(STDOUT)
-      self.log_level = opts[:log_level] || Logger::ERROR
+      self.log_level = opts[:log_level] || Logger::WARN
 
 
       if opts[:logger].nil?

--- a/spec/unleash/configuration_spec.rb
+++ b/spec/unleash/configuration_spec.rb
@@ -37,6 +37,11 @@ RSpec.describe Unleash do
       expect{ config.validate! }.not_to raise_error
     end
 
+    it "should be lenient if disable_client is true" do
+      config = Unleash::Configuration.new(disable_client: true)
+      expect{ config.validate! }.not_to raise_error
+    end
+
     it "support yield for setting the configuration" do
       Unleash.configure do |config|
         config.url      = 'http://test-url/'

--- a/spec/unleash_spec.rb
+++ b/spec/unleash_spec.rb
@@ -1,0 +1,12 @@
+require "spec_helper"
+
+
+RSpec.describe Unleash do
+  it "has a version number" do
+    expect(Unleash::VERSION).not_to be nil
+  end
+
+  it "does something useful" do
+    expect(false).to eq(false)
+  end
+end

--- a/unleash-client.gemspec
+++ b/unleash-client.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "murmurhash3", "~> 0.1.6"
 
-  spec.add_development_dependency "bundler", "~> 1.14"
+  spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "webmock", "~> 3.0"


### PR DESCRIPTION
This can be useful if you are testing you application in an automated way, and
 neither want to have unleash configured, nor have it ever attempt to connect
 to a remote host.