### PR TITLE
Default result always override result when it set as true

### DIFF
--- a/lib/unleash/feature_toggle.rb
+++ b/lib/unleash/feature_toggle.rb
@@ -72,13 +72,12 @@ module Unleash
 
     # only check if it is enabled, do not do metrics
     def am_enabled?(context, default_result)
-      strategy_result = ( self.strategies.select{ |s|
+      result = self.enabled ? ( self.strategies.select{ |s|
         strategy = Unleash::STRATEGIES.fetch(s.name.to_sym, :unknown)
         r = strategy.is_enabled?(s.params, context)
         Unleash.logger.debug "Strategy #{s.name} returned #{r} with context: #{context}" #"for params #{s.params} "
         r
-      }.any? || self.strategies.empty? )
-      result = self.enabled ? strategy_result : default_result
+      }.any? || self.strategies.empty? ) : default_result
 
       Unleash.logger.debug "FeatureToggle (enabled:#{self.enabled} default_result:#{default_result} and Strategies combined returned #{result})"
       return result

--- a/lib/unleash/feature_toggle.rb
+++ b/lib/unleash/feature_toggle.rb
@@ -72,12 +72,18 @@ module Unleash
 
     # only check if it is enabled, do not do metrics
     def am_enabled?(context, default_result)
-      result = self.enabled ? ( self.strategies.select{ |s|
-        strategy = Unleash::STRATEGIES.fetch(s.name.to_sym, :unknown)
-        r = strategy.is_enabled?(s.params, context)
-        Unleash.logger.debug "Strategy #{s.name} returned #{r} with context: #{context}" #"for params #{s.params} "
-        r
-      }.any? || self.strategies.empty? ) : default_result
+      result =
+        if self.enabled
+          self.strategies.empty? ||
+          self.strategies.select{ |s|
+            strategy = Unleash::STRATEGIES.fetch(s.name.to_sym, :unknown)
+            r = strategy.is_enabled?(s.params, context)
+            Unleash.logger.debug "Strategy #{s.name} returned #{r} with context: #{context}" #"for params #{s.params} "
+            r
+          }.any?
+        else
+          default_result
+        end
 
       Unleash.logger.debug "FeatureToggle (enabled:#{self.enabled} default_result:#{default_result} and Strategies combined returned #{result})"
       return result

--- a/lib/unleash/feature_toggle.rb
+++ b/lib/unleash/feature_toggle.rb
@@ -72,13 +72,13 @@ module Unleash
 
     # only check if it is enabled, do not do metrics
     def am_enabled?(context, default_result)
-      result = self.enabled && ( self.strategies.select{ |s|
+      strategy_result = ( self.strategies.select{ |s|
         strategy = Unleash::STRATEGIES.fetch(s.name.to_sym, :unknown)
         r = strategy.is_enabled?(s.params, context)
         Unleash.logger.debug "Strategy #{s.name} returned #{r} with context: #{context}" #"for params #{s.params} "
         r
       }.any? || self.strategies.empty? )
-      result ||= default_result
+      result = self.enabled ? strategy_result : default_result
 
       Unleash.logger.debug "FeatureToggle (enabled:#{self.enabled} default_result:#{default_result} and Strategies combined returned #{result})"
       return result

--- a/spec/unleash/feature_toggle_spec.rb
+++ b/spec/unleash/feature_toggle_spec.rb
@@ -20,20 +20,22 @@ RSpec.describe Unleash::FeatureToggle do
 
   describe 'FeatureToggle with empty strategies' do
     let(:feature_toggle) { Unleash::FeatureToggle.new(
-      name: 'test',
-      enabled: true,
-      strategies: [],
-      variants: nil
+      JSON.parse('{
+          "name": "test",
+          "enabled": true,
+          "strategies": [],
+          "variants": []
+        }')
       ) }
 
-    it 'should return true if default is true' do
+    it 'should return true if enabled, and default is true' do
       context = Unleash::Context.new(user_id: 1)
       expect(feature_toggle.is_enabled?(context, true)).to be_truthy
     end
 
-    it 'should return false if default is false' do
+    it 'should return true if enabled, and default is false' do
       context = Unleash::Context.new(user_id: 1)
-      expect(feature_toggle.is_enabled?(context, false)).to be_falsey
+      expect(feature_toggle.is_enabled?(context, false)).to be_truthy
     end
   end
 

--- a/spec/unleash/feature_toggle_spec.rb
+++ b/spec/unleash/feature_toggle_spec.rb
@@ -26,8 +26,116 @@ RSpec.describe Unleash::FeatureToggle do
       variants: nil
       ) }
 
-    it 'should return true' do
+    it 'should return true if default is true' do
       context = Unleash::Context.new(user_id: 1)
+      expect(feature_toggle.is_enabled?(context, true)).to be_truthy
+    end
+
+    it 'should return false if default is false' do
+      context = Unleash::Context.new(user_id: 1)
+      expect(feature_toggle.is_enabled?(context, false)).to be_falsey
+    end
+  end
+
+  describe 'FeatureToggle with empty strategies and disabled toggle' do
+    let(:feature_toggle) { Unleash::FeatureToggle.new(
+      JSON.parse('{
+          "name": "Test.userid",
+          "description": null,
+          "enabled": false,
+          "strategies": [],
+          "variants": [],
+          "createdAt": "2019-01-24T10:41:45.236Z"
+        }')
+      ) }
+
+    it 'should return false if disabled and default is false' do
+      context = Unleash::Context.new(user_id: 1)
+      expect(feature_toggle.is_enabled?(context, false)).to be_falsey
+    end
+
+    it 'should return true if disabled and default is true' do
+      context = Unleash::Context.new(user_id: 1)
+      expect(feature_toggle.is_enabled?(context, true)).to be_truthy
+    end
+  end
+
+  describe 'FeatureToggle with userId strategy and enabled toggle' do
+    let(:feature_toggle) { Unleash::FeatureToggle.new(
+      JSON.parse('{
+          "name": "Test.userid",
+          "description": null,
+          "enabled": true,
+          "strategies": [
+            {
+              "name": "userWithId",
+              "parameters": {
+                "userIds": "12345"
+              }
+            }
+          ],
+          "variants": [],
+          "createdAt": "2019-01-24T10:41:45.236Z"
+        }')
+      ) }
+
+    it 'should return true if enabled, user_id matched, and default is true' do
+      context = Unleash::Context.new(user_id: "12345")
+      expect(feature_toggle.is_enabled?(context, true)).to be_truthy
+    end
+
+    it 'should return true if enabled, user_id matched, and default is false' do
+      context = Unleash::Context.new(user_id: "12345")
+      expect(feature_toggle.is_enabled?(context, false)).to be_truthy
+    end
+
+    it 'should return false if enabled, user_id unmatched, and default is true' do
+      context = Unleash::Context.new(user_id: "54321")
+      expect(feature_toggle.is_enabled?(context, true)).to be_falsey
+    end
+
+    it 'should return false if enabled, user_id unmatched, and default is false' do
+      context = Unleash::Context.new(user_id: "54321")
+      expect(feature_toggle.is_enabled?(context, false)).to be_falsey
+    end
+  end
+
+  describe 'FeatureToggle with userId strategy and disabled toggle' do
+    let(:feature_toggle) { Unleash::FeatureToggle.new(
+      JSON.parse('{
+          "name": "Test.userid",
+          "description": null,
+          "enabled": false,
+          "strategies": [
+            {
+              "name": "userWithId",
+              "parameters": {
+                "userIds": "12345"
+              }
+            }
+          ],
+          "variants": [],
+          "createdAt": "2019-01-24T10:41:45.236Z"
+        }')
+      ) }
+
+    it 'should return false if disabled, user_id matched, and default is false' do
+      context = Unleash::Context.new(user_id: "12345")
+      expect(feature_toggle.is_enabled?(context, false)).to be_falsey
+    end
+
+    it 'should return false if disabled, user_id unmatched, and default is false' do
+      context = Unleash::Context.new(user_id: "54321")
+      expect(feature_toggle.is_enabled?(context, false)).to be_falsey
+    end
+
+    it 'should return true if disabled, user_id matched, and default is true' do
+      context = Unleash::Context.new(user_id: "12345")
+      expect(feature_toggle.is_enabled?(context, true)).to be_truthy
+    end
+
+    it 'should return true if disabled, user_id unmatched, and default is true' do
+      context = Unleash::Context.new(user_id: "54321")
       expect(feature_toggle.is_enabled?(context, true)).to be_truthy
     end
   end

--- a/spec/unleash/feature_toggle_spec.rb
+++ b/spec/unleash/feature_toggle_spec.rb
@@ -20,13 +20,11 @@ RSpec.describe Unleash::FeatureToggle do
 
   describe 'FeatureToggle with empty strategies' do
     let(:feature_toggle) { Unleash::FeatureToggle.new(
-      JSON.parse('{
-          "name": "test",
-          "enabled": true,
-          "strategies": [],
-          "variants": []
-        }')
-      ) }
+      "name" => "test",
+      "enabled" => true,
+      "strategies" => [],
+      "variants" => nil
+    ) }
 
     it 'should return true if enabled, and default is true' do
       context = Unleash::Context.new(user_id: 1)
@@ -41,15 +39,13 @@ RSpec.describe Unleash::FeatureToggle do
 
   describe 'FeatureToggle with empty strategies and disabled toggle' do
     let(:feature_toggle) { Unleash::FeatureToggle.new(
-      JSON.parse('{
-          "name": "Test.userid",
-          "description": null,
-          "enabled": false,
-          "strategies": [],
-          "variants": [],
-          "createdAt": "2019-01-24T10:41:45.236Z"
-        }')
-      ) }
+      "name" => "Test.userid",
+      "description" => nil,
+      "enabled" => false,
+      "strategies" => [],
+      "variants" => nil,
+      "createdAt" => "2019-01-24T10:41:45.236Z"
+    ) }
 
     it 'should return false if disabled and default is false' do
       context = Unleash::Context.new(user_id: 1)
@@ -64,22 +60,20 @@ RSpec.describe Unleash::FeatureToggle do
 
   describe 'FeatureToggle with userId strategy and enabled toggle' do
     let(:feature_toggle) { Unleash::FeatureToggle.new(
-      JSON.parse('{
-          "name": "Test.userid",
-          "description": null,
-          "enabled": true,
-          "strategies": [
-            {
-              "name": "userWithId",
-              "parameters": {
-                "userIds": "12345"
-              }
-            }
-          ],
-          "variants": [],
-          "createdAt": "2019-01-24T10:41:45.236Z"
-        }')
-      ) }
+      "name" => "Test.userid",
+      "description" => nil,
+      "enabled" => true,
+      "strategies" => [
+        {
+          "name" => "userWithId",
+          "parameters" => {
+            "userIds" => "12345"
+          }
+        }
+      ],
+      "variants" => nil,
+      "createdAt" => "2019-01-24T10:41:45.236Z"
+    ) }
 
     it 'should return true if enabled, user_id matched, and default is true' do
       context = Unleash::Context.new(user_id: "12345")
@@ -104,22 +98,20 @@ RSpec.describe Unleash::FeatureToggle do
 
   describe 'FeatureToggle with userId strategy and disabled toggle' do
     let(:feature_toggle) { Unleash::FeatureToggle.new(
-      JSON.parse('{
-          "name": "Test.userid",
-          "description": null,
-          "enabled": false,
-          "strategies": [
-            {
-              "name": "userWithId",
-              "parameters": {
-                "userIds": "12345"
-              }
-            }
-          ],
-          "variants": [],
-          "createdAt": "2019-01-24T10:41:45.236Z"
-        }')
-      ) }
+      "name" => "Test.userid",
+      "description" => nil,
+      "enabled" => false,
+      "strategies" => [
+        {
+          "name" => "userWithId",
+          "parameters" => {
+            "userIds" => "12345"
+          }
+        }
+      ],
+      "variants" => nil,
+      "createdAt" => "2019-01-24T10:41:45.236Z"
+    ) }
 
     it 'should return false if disabled, user_id matched, and default is false' do
       context = Unleash::Context.new(user_id: "12345")
@@ -143,27 +135,26 @@ RSpec.describe Unleash::FeatureToggle do
   end
 
   describe 'FeatureToggle with variants' do
-    let(:feature_toggle) { Unleash::FeatureToggle.new(JSON.parse('{
-        "name": "Test.variants",
-        "description": null,
-        "enabled": true,
-        "strategies": [
-          {
-            "name": "default"
-          }
-        ],
-        "variants": [
-          {
-            "name": "variant1",
-            "weight": 50
-          },
-          {
-            "name": "variant2",
-            "weight": 50
-          }
-        ],
-        "createdAt": "2019-01-24T10:41:45.236Z"
-      }')
+    let(:feature_toggle) { Unleash::FeatureToggle.new(
+      "name" => "Test.variants",
+      "description" => nil,
+      "enabled" => true,
+      "strategies" => [
+        {
+          "name" => "default"
+        }
+      ],
+      "variants" => [
+        {
+          "name" => "variant1",
+          "weight" => 50
+        },
+        {
+          "name" => "variant2",
+          "weight" => 50
+        }
+      ],
+      "createdAt" => "2019-01-24T10:41:45.236Z"
     ) }
 
     let(:default_variant) { Unleash::Variant.new(name: 'unknown', default: true) }
@@ -185,31 +176,30 @@ RSpec.describe Unleash::FeatureToggle do
   end
 
   describe 'FeatureToggle including weightless variants' do
-    let(:feature_toggle) { Unleash::FeatureToggle.new(JSON.parse('{
-        "name": "Test.variants",
-        "description": null,
-        "enabled": true,
-        "strategies": [
-          {
-            "name": "default"
-          }
-        ],
-        "variants": [
-          {
-            "name": "variantA",
-            "weight": 0
-          },
-          {
-            "name": "variantB",
-            "weight": 10
-          },
-          {
-            "name": "variantC",
-            "weight": 20
-          }
-        ],
-        "createdAt": "2019-01-24T10:41:45.236Z"
-      }')
+    let(:feature_toggle) { Unleash::FeatureToggle.new(
+      "name" => "Test.variants",
+      "description" => nil,
+      "enabled" => true,
+      "strategies" => [
+        {
+          "name" => "default"
+        }
+      ],
+      "variants" => [
+        {
+          "name" => "variantA",
+          "weight" => 0
+        },
+        {
+          "name" => "variantB",
+          "weight" => 10
+        },
+        {
+          "name" => "variantC",
+          "weight" => 20
+        }
+      ],
+      "createdAt" => "2019-01-24T10:41:45.236Z"
     ) }
     let(:default_variant) { Unleash::Variant.new(name: 'unknown', default: true) }
 
@@ -226,27 +216,26 @@ RSpec.describe Unleash::FeatureToggle do
   end
 
   describe 'FeatureToggle with variants which have all zero weight' do
-    let(:feature_toggle) { Unleash::FeatureToggle.new(JSON.parse('{
-        "name": "Test.variants",
-        "description": null,
-        "enabled": true,
-        "strategies": [
-          {
-            "name": "default"
-          }
-        ],
-        "variants": [
-          {
-            "name": "variantA",
-            "weight": 0
-          },
-          {
-            "name": "variantB",
-            "weight": 0
-          }
-        ],
-        "createdAt": "2019-01-24T10:41:45.236Z"
-      }')
+    let(:feature_toggle) { Unleash::FeatureToggle.new(
+      "name" => "Test.variants",
+      "description" => nil,
+      "enabled" => true,
+      "strategies" => [
+        {
+          "name" => "default"
+        }
+      ],
+      "variants" => [
+        {
+          "name" => "variantA",
+          "weight" => 0
+        },
+        {
+          "name" => "variantB",
+          "weight" => 0
+        }
+      ],
+      "createdAt" => "2019-01-24T10:41:45.236Z"
     ) }
     let(:default_variant) { Unleash::Variant.new(name: 'unknown', default: true) }
 
@@ -262,39 +251,38 @@ RSpec.describe Unleash::FeatureToggle do
   end
 
   describe 'FeatureToggle with variants that have a variant override' do
-    let(:feature_toggle) { Unleash::FeatureToggle.new(JSON.parse('{
-        "name": "Test.variants",
-        "description": null,
-        "enabled": true,
-        "strategies": [
-          {
-            "name": "default"
-          }
-        ],
-        "variants": [
-          {
-            "name": "variant1",
-            "weight": 50,
-            "payload": {
-              "type": "string",
-              "value": "val1"
-            },
-            "overrides": [{
-              "contextName": "userId",
-              "values": ["132", "61"]
-            }]
+    let(:feature_toggle) { Unleash::FeatureToggle.new(
+      "name" => "Test.variants",
+      "description" => nil,
+      "enabled" => true,
+      "strategies" => [
+        {
+          "name" => "default"
+        }
+      ],
+      "variants" => [
+        {
+          "name" => "variant1",
+          "weight" => 50,
+          "payload" => {
+            "type" => "string",
+            "value" => "val1"
           },
-          {
-              "name": "variant2",
-              "weight": 50,
-              "payload": {
-                "type": "string",
-                "value": "val2"
-              }
-          }
-        ],
-        "createdAt": "2019-01-24T10:41:45.236Z"
-      }')
+          "overrides" => [{
+            "contextName" => "userId",
+            "values" => ["132", "61"]
+          }]
+        },
+        {
+            "name" => "variant2",
+            "weight" => 50,
+            "payload" => {
+              "type" => "string",
+              "value" => "val2"
+            }
+        }
+      ],
+      "createdAt" => "2019-01-24T10:41:45.236Z"
     ) }
 
     it 'should return variant1 for user_id:61 from override' do
@@ -320,18 +308,17 @@ RSpec.describe Unleash::FeatureToggle do
   end
 
   describe 'FeatureToggle with no variants' do
-    let(:feature_toggle) { Unleash::FeatureToggle.new(JSON.parse('{
-        "name": "Test.variants",
-        "description": null,
-        "enabled": true,
-        "strategies": [
-          {
-            "name": "default"
-          }
-        ],
-        "variants": [],
-        "createdAt": "2019-01-24T10:41:45.236Z"
-      }')
+    let(:feature_toggle) { Unleash::FeatureToggle.new(
+      "name" => "Test.variants",
+      "description" => nil,
+      "enabled" => true,
+      "strategies" => [
+        {
+          "name" => "default"
+        }
+      ],
+      "variants" => [],
+      "createdAt" => "2019-01-24T10:41:45.236Z"
     ) }
     let(:default_variant) { Unleash::Variant.new(name: 'unknown', default: true) }
 


### PR DESCRIPTION
After test the result combinations with default result, it does not work as expected when default value is true. It will always override combined result as true regardless the combined result of toggle is enabled and strategy result.

https://github.com/Unleash/unleash-client-ruby/blob/master/lib/unleash/feature_toggle.rb#L74..L81

The modification will be - when strategy result already computed and toggle is enabled, it may respect that combined result instead of default result.