### PR TITLE
Fix an issue with undefined default_variant

### DIFF
--- a/lib/unleash/client.rb
+++ b/lib/unleash/client.rb
@@ -59,24 +59,26 @@ module Unleash
     def get_variant(feature, context = nil, fallback_variant = nil)
       Unleash.logger.debug "Unleash::Client.get_variant for feature: #{feature} with context #{context}"
 
+      default_variant = fallback_variant || Unleash::FeatureToggle.new.disabled_variant
+
       if Unleash.configuration.disable_client
         Unleash.logger.debug "unleash_client is disabled! Always returning #{default_variant} for feature #{feature}!"
-        return fallback_variant || Unleash::FeatureToggle.disabled_variant
+        return default_variant
       end
 
       toggle_as_hash = Unleash&.toggles&.select{ |toggle| toggle['name'] == feature }&.first
 
       if toggle_as_hash.nil?
         Unleash.logger.debug "Unleash::Client.get_variant feature: #{feature} not found"
-        return fallback_variant || Unleash::FeatureToggle.disabled_variant
+        return default_variant
       end
 
       toggle = Unleash::FeatureToggle.new(toggle_as_hash)
-      variant = toggle.get_variant(context, fallback_variant)
+      variant = toggle.get_variant(context, default_variant)
 
       if variant.nil?
         Unleash.logger.debug "Unleash::Client.get_variant variants for feature: #{feature} not found"
-        return fallback_variant || Unleash::FeatureToggle.disabled_variant
+        return default_variant
       end
 
       # TODO: Add to README: name, payload, enabled (bool)

--- a/lib/unleash/feature_toggle.rb
+++ b/lib/unleash/feature_toggle.rb
@@ -47,6 +47,10 @@ module Unleash
       variant
     end
 
+    def disabled_variant
+      Unleash::Variant.new(name: 'disabled', enabled: false)
+    end
+
     private
 
     # only check if it is enabled, do not do metrics
@@ -75,10 +79,6 @@ module Unleash
 
     def strategy_constraint_matches?(strategy, context)
       strategy.constraints.empty? || strategy.constraints.all?{ |c| c.matches_context?(context) }
-    end
-
-    def disabled_variant
-      Unleash::Variant.new(name: 'disabled', enabled: false)
     end
 
     def sum_variant_defs_weights

--- a/spec/unleash/client_spec.rb
+++ b/spec/unleash/client_spec.rb
@@ -96,29 +96,31 @@ RSpec.describe Unleash::Client do
 
     features_response_body = '{
       "version": 1,
-      "features": {
-        "name": "toggleName",
-        "enabled": true,
-        "strategies": [{ "name": "default" }],
-        "variants": [
-          {
-            "name": "a",
-            "weight": 50,
-            "payload": {
-              "type": "string",
-              "value": ""
+      "features": [
+        {
+          "name": "toggleName",
+          "enabled": true,
+          "strategies": [{ "name": "default" }],
+          "variants": [
+            {
+              "name": "a",
+              "weight": 50,
+              "payload": {
+                "type": "string",
+                "value": ""
+              }
+            },
+            {
+              "name": "b",
+              "weight": 50,
+              "payload": {
+                "type": "string",
+                "value": ""
+              }
             }
-          },
-          {
-            "name": "b",
-            "weight": 50,
-            "payload": {
-              "type": "string",
-              "value": ""
-            }
-          }
-        ]
-      }
+          ]
+        }
+      ]
     }'
 
     WebMock.stub_request(:get, "http://test-url//client/features")
@@ -154,6 +156,13 @@ RSpec.describe Unleash::Client do
     expect(
       unleash_client.is_enabled?('toggleName', {}, true)
     ).to eq(true)
+
+    expect(
+      unleash_client.get_variant('toggleName', Unleash::Context.new(user_id: 42))
+    ).to eq(Unleash::Variant.new(name: 'a', enabled: true, payload: {
+      'type' => 'string',
+      'value' => ''
+    }))
 
     expect(WebMock).not_to have_requested(:get, 'http://test-url/')
     expect(WebMock).to have_requested(:post, 'http://test-url//client/register')


### PR DESCRIPTION
This also addressed a couple instances of duplication around the same working logic.

To have the expected behavior, I had to expose the `disabled_variant` method. I feel like this could use considerably more work getting several aspects that I think might not be tested/working correctly, so if we see value in that I'm happy working at improving the coverage. At the moment though, this at least gets the `get_variant` method working.