### PR TITLE
Windows File permissions fix

### DIFF
--- a/lib/unleash/toggle_fetcher.rb
+++ b/lib/unleash/toggle_fetcher.rb
@@ -71,6 +71,7 @@ module Unleash
         self.toggle_lock.synchronize do
           file = File.open(backup_file_tmp, "w")
           file.write(self.toggle_cache.to_json)
+          file.close
           File.rename(backup_file_tmp, backup_file)
         end
       rescue StandardError => e


### PR DESCRIPTION
I was getting a bit annoyed at an error the unleash client was putting in my console whenever I was doing local dev on my windows machine for a website I'm working on.

I've found windows to be very particular when it comes to file operations and it was complaining about permissions whenever I ran my site or even just a rake command

```
E, [2020-12-08T16:10:54.775034 #18340] ERROR -- : Unable to save backup file. Exception thrown Errno::EACCES:'Permission denied @ rb_file_s_rename - (C:/Users/Alex/AppData/Local/Temp/unleash--repo.json.tmp, C:/Users/Alex/AppData/Local/Temp/unleash--repo.json)'
E, [2020-12-08T16:10:54.775427 #18340] ERROR -- : stacktrace: ["C:/Ruby26-x64/lib/ruby/gems/2.6.0/gems/unleash-3.2.0/lib/unleash/toggle_fetcher.rb:74:in `rename'", "C:/Ruby26-x64/lib/ruby/gems/2.6.0/gems/unleash-3.2.0/lib/unleash/toggle_fetcher.rb:74:in `block in save!'"
```

It wasn't causing any major issues as far as I can tell, but given it's a small simple fix I decided to get the fix done.
By closing the file before doing the rename it stops the error from happening. The file object doesn't get used after the write and rename anyway so there shouldn't be any problem closing it early.

The error wasn't showing up in the tests even though that code was getting hit which was weird, but that's why I haven't adjusted any test files.