### PR TITLE
Update ruby_version requirement to allow Ruby 3.0

### DIFF
--- a/unleash-client.gemspec
+++ b/unleash-client.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.bindir        = 'bin'
   spec.executables   = spec.files.grep(%r{^bin/unleash}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
-  spec.required_ruby_version = "~> 2.5"
+  spec.required_ruby_version = ">= 2.5"
 
   spec.add_dependency "murmurhash3", "~> 0.1.6"
 


### PR DESCRIPTION
This is just recreating PR #43 into a separate branch, instead of going directly to master.