### PR TITLE
Fix backup_file being created too early

### DIFF
--- a/lib/unleash/configuration.rb
+++ b/lib/unleash/configuration.rb
@@ -26,7 +26,7 @@ module Unleash
       initialize_default_logger if opts[:logger].nil?
 
       merge(opts)
-      refresh_backup_file!
+      refresh_backup_file! if app_name.present?
     end
 
     def metrics_interval_in_millis

--- a/spec/unleash/configuration_spec.rb
+++ b/spec/unleash/configuration_spec.rb
@@ -51,6 +51,7 @@ RSpec.describe Unleash do
       expect(Unleash.configuration.url).to eq('http://test-url/')
       expect(Unleash.configuration.app_name).to eq('my-test-app')
       expect(Unleash.configuration.fetch_toggles_url).to eq('http://test-url//client/features')
+      expect(Unleash.configuration.backup_file).to eq("#{Dir.tmpdir}/unleash-my-test-app-repo.json")
     end
 
     it "should build the correct unleash endpoints from the base url" do


### PR DESCRIPTION
`backup_file` is eagerly created when the Configuration is initialized.

 When configuring with a block, the Configuration is initialized with defaults before control is yielded. This causes `backup_file` to be named `unleash--repo.json` regardless of the `app_name` assignment in the block. The filename default should respect block assignment.