### PR TITLE
fix: only send metrics if there is data to send. (#58)

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -113,6 +113,9 @@ Style/SoleNestedConditional:
   Enabled: true
 Style/StringConcatenation:
   Enabled: false
+Style/TrailingCommaInHashLiteral:
+  Enabled: true
+#  EnforcedStyleForMultiline: consistent_comma
 
 Layout/BeginEndAlignment:
   Enabled: true

--- a/lib/unleash.rb
+++ b/lib/unleash.rb
@@ -24,11 +24,6 @@ module Unleash
     attr_accessor :configuration, :toggle_fetcher, :toggles, :toggle_metrics, :reporter, :logger
   end
 
-  def self.initialize
-    self.toggles = []
-    self.toggle_metrics = {}
-  end
-
   # Support for configuration via yield:
   def self.configure
     self.configuration ||= Unleash::Configuration.new

--- a/lib/unleash/client.rb
+++ b/lib/unleash/client.rb
@@ -94,7 +94,7 @@ module Unleash
     def shutdown
       unless Unleash.configuration.disable_client
         Unleash.toggle_fetcher.save!
-        Unleash.reporter.send unless Unleash.configuration.disable_metrics
+        Unleash.reporter.post unless Unleash.configuration.disable_metrics
         shutdown!
       end
     end
@@ -141,7 +141,7 @@ module Unleash
         Unleash.configuration.retry_limit
       )
       self.metrics_scheduled_executor.run do
-        Unleash.reporter.send
+        Unleash.reporter.post
       end
     end
 

--- a/lib/unleash/metrics_reporter.rb
+++ b/lib/unleash/metrics_reporter.rb
@@ -6,6 +6,8 @@ require 'time'
 
 module Unleash
   class MetricsReporter
+    LONGEST_WITHOUT_A_REPORT = 600
+
     attr_accessor :last_time
 
     def initialize
@@ -33,16 +35,28 @@ module Unleash
       report
     end
 
-    def send
-      Unleash.logger.debug "send() Report"
+    def post
+      Unleash.logger.debug "post() Report"
+
+      if bucket_empty? && (Time.now - self.last_time < LONGEST_WITHOUT_A_REPORT) # and last time is less then 10 minutes...
+        Unleash.logger.debug "Report not posted to server, as it would have been empty. (and has been empty for up to 10 min)"
+
+        return
+      end
 
       response = Unleash::Util::Http.post(Unleash.configuration.client_metrics_uri, self.generate_report.to_json)
 
       if ['200', '202'].include? response.code
-        Unleash.logger.debug "Report sent to unleash server sucessfully. Server responded with http code #{response.code}"
+        Unleash.logger.debug "Report sent to unleash server successfully. Server responded with http code #{response.code}"
       else
         Unleash.logger.error "Error when sending report to unleash server. Server responded with http code #{response.code}."
       end
+    end
+
+    private
+
+    def bucket_empty?
+      Unleash.toggle_metrics.features.empty?
     end
   end
 end

--- a/spec/unleash/client_spec.rb
+++ b/spec/unleash/client_spec.rb
@@ -23,6 +23,18 @@ RSpec.describe Unleash::Client do
         }
       )
       .to_return(status: 200, body: "", headers: {})
+
+    simple_features = {
+      "version": 1,
+      "features": [
+        {
+          "name": "Feature.A",
+          "description": "Enabled toggle",
+          "enabled": true,
+          "strategies": [{ "name": "default" }]
+        }
+      ]
+    }
     WebMock.stub_request(:get, "http://test-url/client/features")
       .with(
         headers: {
@@ -35,7 +47,7 @@ RSpec.describe Unleash::Client do
           'X-Api-Key' => '123'
         }
       )
-      .to_return(status: 200, body: "", headers: {})
+      .to_return(status: 200, body: simple_features.to_json, headers: {})
 
     Unleash.configure do |config|
       config.url      = 'http://test-url/'
@@ -69,7 +81,19 @@ RSpec.describe Unleash::Client do
     ).to have_been_made.once
 
     # Test now sending of metrics
-    Unleash.reporter.send
+    # Not sending metrics, if no feature flags were evaluated:
+    Unleash.reporter.post
+    expect(
+      a_request(:post, "http://test-url/client/metrics")
+        .with(headers: { 'Content-Type': 'application/json' })
+        .with(headers: { 'X-API-KEY': '123', 'Content-Type': 'application/json' })
+        .with(headers: { 'UNLEASH-APPNAME': 'my-test-app' })
+        .with(headers: { 'UNLEASH-INSTANCEID': 'rspec/test' })
+    ).not_to have_been_made
+
+    # Sending metrics, if they have been evaluated:
+    unleash_client.is_enabled?("Feature.A")
+    Unleash.reporter.post
     expect(
       a_request(:post, "http://test-url/client/metrics")
       .with(headers: { 'Content-Type': 'application/json' })

--- a/spec/unleash/metrics_reporter_spec.rb
+++ b/spec/unleash/metrics_reporter_spec.rb
@@ -1,0 +1,115 @@
+require "spec_helper"
+require "rspec/json_expectations"
+
+RSpec.describe Unleash::MetricsReporter do
+  let(:metrics_reporter) { Unleash::MetricsReporter.new }
+
+  before do
+    Unleash.configuration = Unleash::Configuration.new
+    Unleash.logger = Unleash.configuration.logger
+    Unleash.logger.level = Unleash.configuration.log_level
+    # Unleash.logger.level = Logger::DEBUG
+    Unleash.toggles = []
+    Unleash.toggle_metrics = {}
+
+    Unleash.configuration.url         = 'http://test-url/'
+    Unleash.configuration.app_name    = 'my-test-app'
+    Unleash.configuration.instance_id = 'rspec/test'
+
+    # Do not test the scheduled calls from client/metrics:
+    Unleash.configuration.disable_client = true
+    Unleash.configuration.disable_metrics = true
+  end
+
+  it "generates the correct report" do
+    Unleash.configure do |config|
+      config.url      = 'http://test-url/'
+      config.app_name = 'my-test-app'
+      config.instance_id = 'rspec/test'
+      config.disable_client = true
+    end
+    Unleash.toggle_metrics = Unleash::Metrics.new
+
+    Unleash.toggle_metrics.increment('featureA', :yes)
+    Unleash.toggle_metrics.increment('featureA', :yes)
+    Unleash.toggle_metrics.increment('featureA', :yes)
+    Unleash.toggle_metrics.increment('featureA', :no)
+    Unleash.toggle_metrics.increment('featureA', :no)
+    Unleash.toggle_metrics.increment('featureB', :yes)
+
+    report = metrics_reporter.generate_report
+    expect(report[:bucket][:toggles]).to include(
+      "featureA" => {
+        no: 2,
+        yes: 3
+      },
+      "featureB" => {
+        no: 0,
+        yes: 1
+      }
+    )
+
+    expect(report[:bucket][:toggles].to_json).to include_json(
+      featureA: {
+        no: 2,
+        yes: 3
+      },
+      featureB: {
+        no: 0,
+        yes: 1
+      }
+    )
+  end
+
+  it "sends the correct report" do
+    WebMock.stub_request(:post, "http://test-url/client/metrics")
+      .with(
+        headers: {
+          'Accept' => '*/*',
+          'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+          'Content-Type' => 'application/json',
+          'Unleash-Appname' => 'my-test-app',
+          'Unleash-Instanceid' => 'rspec/test',
+          'User-Agent' => 'Ruby'
+        }
+      )
+      .to_return(status: 200, body: "", headers: {})
+
+    Unleash.toggle_metrics = Unleash::Metrics.new
+
+    Unleash.toggle_metrics.increment('featureA', :yes)
+    Unleash.toggle_metrics.increment('featureA', :yes)
+    Unleash.toggle_metrics.increment('featureA', :yes)
+    Unleash.toggle_metrics.increment('featureA', :no)
+    Unleash.toggle_metrics.increment('featureA', :no)
+    Unleash.toggle_metrics.increment('featureB', :yes)
+
+    metrics_reporter.post
+
+    expect(WebMock).to have_requested(:post, 'http://test-url/client/metrics')
+      .with { |req|
+        hash = JSON.parse(req.body)
+
+        [
+          DateTime.parse(hash['bucket']['stop']) >= DateTime.parse(hash['bucket']['start']),
+          hash['bucket']['toggles']['featureA']['yes'] == 3,
+          hash['bucket']['toggles']['featureA']['no'] == 2,
+          hash['bucket']['toggles']['featureB']['yes'] == 1
+        ].all?(true)
+      }
+      .with(
+        body: hash_including(
+          appName: "my-test-app",
+          instanceId: "rspec/test"
+        )
+      )
+  end
+
+  it "does not send a report, if there were no metrics registered/evaluated" do
+    Unleash.toggle_metrics = Unleash::Metrics.new
+
+    metrics_reporter.post
+
+    expect(WebMock).to_not have_requested(:post, 'http://test-url/client/metrics')
+  end
+end


### PR DESCRIPTION
We want to preserve the backend from having to work, when there is no work to be done.