### PR TITLE
tests: make tests pass in context matching

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -17,6 +17,7 @@ Metrics/BlockLength:
   Max: 100
   Exclude:
     - 'spec/unleash/client_spec.rb'
+    - 'spec/unleash/context_spec.rb'
     - 'spec/unleash/feature_toggle_spec.rb'
 
 Metrics/AbcSize:

--- a/spec/unleash/context_spec.rb
+++ b/spec/unleash/context_spec.rb
@@ -82,7 +82,8 @@ RSpec.describe Unleash::Context do
       userId: '123',
       session_id: 'verylongsesssionid',
       properties: {
-        fancy: 'polarbear'
+        fancy: 'polarbear',
+        countryCode: 'DK'
       }
     }
     context = Unleash::Context.new(params)
@@ -97,6 +98,12 @@ RSpec.describe Unleash::Context do
     expect(context.get_by_name(:fancy)).to eq('polarbear')
     expect(context.get_by_name('fancy')).to eq('polarbear')
     expect(context.get_by_name('Fancy')).to eq('polarbear')
+    expect{ context.get_by_name(:country_code) }.to raise_error(KeyError)
+    expect{ context.get_by_name('country_code') }.to raise_error(KeyError)
+    expect{ context.get_by_name('countryCode') }.to raise_error(KeyError)
+    expect{ context.get_by_name(:countryCode) }.to raise_error(KeyError)
+    expect{ context.get_by_name('CountryCode') }.to raise_error(KeyError)
+    expect{ context.get_by_name(:CountryCode) }.to raise_error(KeyError)
   end
 
   it "when using get_by_name with keys as strings" do
@@ -104,7 +111,8 @@ RSpec.describe Unleash::Context do
       'user_id' => '123',
       'sessionId' => 'verylongsesssionid',
       'properties' => {
-        'fancy' => 'polarbear'
+        'fancy' => 'polarbear',
+        'country_code' => 'UK'
       }
     }
     context = Unleash::Context.new(params)
@@ -119,5 +127,11 @@ RSpec.describe Unleash::Context do
     expect(context.get_by_name(:fancy)).to eq('polarbear')
     expect(context.get_by_name('fancy')).to eq('polarbear')
     expect(context.get_by_name('Fancy')).to eq('polarbear')
+    expect(context.get_by_name('country_code')).to eq('UK')
+    expect(context.get_by_name(:country_code)).to eq('UK')
+    expect(context.get_by_name('countryCode')).to eq('UK')
+    expect(context.get_by_name(:countryCode)).to eq('UK')
+    expect(context.get_by_name('CountryCode')).to eq('UK')
+    expect(context.get_by_name(:CountryCode)).to eq('UK')
   end
 end


### PR DESCRIPTION
make it explicit the current state of matching.

It would be good to have this PR merged before #69  as this includes tests for some use-cases that are affected there.