### PR TITLE
fix: Allow context to correctly resolve camelCase property values

### DIFF
--- a/lib/unleash/context.rb
+++ b/lib/unleash/context.rb
@@ -28,7 +28,7 @@ module Unleash
       if ATTRS.include? normalized_name
         self.send(normalized_name)
       else
-        self.properties.fetch(normalized_name)
+        self.properties.fetch(normalized_name, nil) || self.properties.fetch(name.to_sym)
       end
     end
 

--- a/spec/unleash/context_spec.rb
+++ b/spec/unleash/context_spec.rb
@@ -98,10 +98,10 @@ RSpec.describe Unleash::Context do
     expect(context.get_by_name(:fancy)).to eq('polarbear')
     expect(context.get_by_name('fancy')).to eq('polarbear')
     expect(context.get_by_name('Fancy')).to eq('polarbear')
+    expect(context.get_by_name('countryCode')).to eq('DK')
+    expect(context.get_by_name(:countryCode)).to eq('DK')
     expect{ context.get_by_name(:country_code) }.to raise_error(KeyError)
     expect{ context.get_by_name('country_code') }.to raise_error(KeyError)
-    expect{ context.get_by_name('countryCode') }.to raise_error(KeyError)
-    expect{ context.get_by_name(:countryCode) }.to raise_error(KeyError)
     expect{ context.get_by_name('CountryCode') }.to raise_error(KeyError)
     expect{ context.get_by_name(:CountryCode) }.to raise_error(KeyError)
   end


### PR DESCRIPTION
Fix an issue where camel case property values being resolved in the context object would incorrectly raise a KeyError