### PR TITLE
chore: standardize default values for metrics_interval and retry_limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Argument | Description | Required? |  Type |  Default Value|
 `environment` | Environment the program is running on. Could be for example `prod` or `dev`. Not yet in use. | N | String | `default` |
 `project_name` | Name of the project to retrieve features from. If not set, all feature flags will be retrieved. | N | String | nil |
 `refresh_interval` | How often the unleash client should check with the server for configuration changes. | N | Integer |  15 |
-`metrics_interval` | How often the unleash client should send metrics to server. | N | Integer | 30 |
+`metrics_interval` | How often the unleash client should send metrics to server. | N | Integer | 60 |
 `disable_client` | Disables all communication with the Unleash server, effectively taking it *offline*. If set, `is_enabled?` will always answer with the `default_value` and configuration validation is skipped. Defeats the entire purpose of using unleash, but can be useful in when running tests. | N | Boolean | `false` |
 `disable_metrics` | Disables sending metrics to Unleash server. | N | Boolean | `false` |
 `custom_http_headers` | Custom headers to send to Unleash. As of Unleash v4.0.0, the `Authorization` header is required. For example: `{'Authorization': '<API token>'}` | N | Hash | {} |

--- a/lib/unleash/configuration.rb
+++ b/lib/unleash/configuration.rb
@@ -87,9 +87,9 @@ module Unleash
       self.disable_client   = false
       self.disable_metrics  = false
       self.refresh_interval = 10
-      self.metrics_interval = 30
+      self.metrics_interval = 60
       self.timeout          = 30
-      self.retry_limit      = 1
+      self.retry_limit      = 5
       self.backup_file      = nil
       self.log_level        = Logger::WARN
 

--- a/spec/unleash/configuration_spec.rb
+++ b/spec/unleash/configuration_spec.rb
@@ -18,9 +18,9 @@ RSpec.describe Unleash do
       expect(config.disable_metrics).to be_falsey
 
       expect(config.refresh_interval).to eq(10)
-      expect(config.metrics_interval).to eq(30)
+      expect(config.metrics_interval).to eq(60)
       expect(config.timeout).to eq(30)
-      expect(config.retry_limit).to eq(1)
+      expect(config.retry_limit).to eq(5)
 
       expect(config.backup_file).to_not be_nil
       expect(config.backup_file).to eq(Dir.tmpdir + '/unleash--repo.json')


### PR DESCRIPTION
to the same values used in the other SDKs