### PR TITLE
chore: add ruby 3.1 support in gh actions

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -16,6 +16,7 @@ jobs:
           - macos
         ruby-version:
           - jruby
+          - 3.1
           - 3.0
           - 2.7
           - 2.6

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Leverage the [Unleash Server](https://github.com/Unleash/unleash) for powerful f
 
 ## Supported Ruby Interpreters
 
+  * MRI 3.1
   * MRI 3.0
   * MRI 2.7
   * MRI 2.6


### PR DESCRIPTION
and document that it is a supported version