### PR TITLE
Default to never disable after failure

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Argument | Description | Required? |  Type |  Default Value|
 `disable_metrics` | Disables sending metrics to Unleash server. | N | Boolean | `false` |
 `custom_http_headers` | Custom headers to send to Unleash. As of Unleash v4.0.0, the `Authorization` header is required. For example: `{'Authorization': '<API token>'}` | N | Hash | {} |
 `timeout` | How long to wait for the connection to be established or wait in reading state (open_timeout/read_timeout) | N | Integer | 30 |
-`retry_limit` | How many consecutive failures in connecting to the Unleash server are allowed before giving up. Use `Float::INFINITY` if you would like it to never give up. | N | Numeric | 5 |
+`retry_limit` | How many consecutive failures in connecting to the Unleash server are allowed before giving up. The default here, `Float::INFINITY`, means the client will never give up. | N | Float::INFINITY | 5 |
 `backup_file` | Filename to store the last known state from the Unleash server. Best to not change this from the default. | N | String | `Dir.tmpdir + "/unleash-#{app_name}-repo.json` |
 `logger` | Specify a custom `Logger` class to handle logs for the Unleash client. | N | Class | `Logger.new(STDOUT)` |
 `log_level` | Change the log level for the `Logger` class. Constant from `Logger::Severity`. | N | Constant | `Logger::WARN` |

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Argument | Description | Required? |  Type |  Default Value|
 `disable_metrics` | Disables sending metrics to Unleash server. | N | Boolean | `false` |
 `custom_http_headers` | Custom headers to send to Unleash. As of Unleash v4.0.0, the `Authorization` header is required. For example: `{'Authorization': '<API token>'}` | N | Hash | {} |
 `timeout` | How long to wait for the connection to be established or wait in reading state (open_timeout/read_timeout) | N | Integer | 30 |
-`retry_limit` | How many consecutive failures in connecting to the Unleash server are allowed before giving up. The default here, `Float::INFINITY`, means the client will never give up. | N | Float::INFINITY | 5 |
+`retry_limit` | How many consecutive failures in connecting to the Unleash server are allowed before giving up. The default is to retry indefinitely. | N | Float::INFINITY | 5 |
 `backup_file` | Filename to store the last known state from the Unleash server. Best to not change this from the default. | N | String | `Dir.tmpdir + "/unleash-#{app_name}-repo.json` |
 `logger` | Specify a custom `Logger` class to handle logs for the Unleash client. | N | Class | `Logger.new(STDOUT)` |
 `log_level` | Change the log level for the `Logger` class. Constant from `Logger::Severity`. | N | Constant | `Logger::WARN` |

--- a/lib/unleash/configuration.rb
+++ b/lib/unleash/configuration.rb
@@ -95,7 +95,7 @@ module Unleash
       self.refresh_interval = 10
       self.metrics_interval = 60
       self.timeout          = 30
-      self.retry_limit      = 5
+      self.retry_limit      = Float::INFINITY
       self.backup_file      = nil
       self.log_level        = Logger::WARN
       self.bootstrap_config = nil

--- a/spec/unleash/configuration_spec.rb
+++ b/spec/unleash/configuration_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Unleash do
       expect(config.refresh_interval).to eq(10)
       expect(config.metrics_interval).to eq(60)
       expect(config.timeout).to eq(30)
-      expect(config.retry_limit).to eq(5)
+      expect(config.retry_limit).to eq(Float::INFINITY)
 
       expect(config.backup_file).to_not be_nil
       expect(config.backup_file).to eq(Dir.tmpdir + '/unleash--repo.json')


### PR DESCRIPTION
By default the client will disable itself after 5 failing API hits, this PR changes this default behaviour to never disable