### PR TITLE
correct logic for default values on feature toggles

### DIFF
--- a/lib/unleash/client.rb
+++ b/lib/unleash/client.rb
@@ -47,7 +47,7 @@ module Unleash
 
       toggle = Unleash::FeatureToggle.new(toggle_as_hash)
 
-      toggle.is_enabled?(context, default_value)
+      toggle.is_enabled?(context)
     end
 
     # enabled? is a more ruby idiomatic method name than is_enabled?

--- a/lib/unleash/feature_toggle.rb
+++ b/lib/unleash/feature_toggle.rb
@@ -23,8 +23,8 @@ module Unleash
       "<FeatureToggle: name=#{name},enabled=#{enabled},strategies=#{strategies},variant_definitions=#{variant_definitions}>"
     end
 
-    def is_enabled?(context, default_result)
-      result = am_enabled?(context, default_result)
+    def is_enabled?(context)
+      result = am_enabled?(context)
 
       choice = result ? :yes : :no
       Unleash.toggle_metrics.increment(name, choice) unless Unleash.configuration.disable_metrics
@@ -37,7 +37,7 @@ module Unleash
 
       context = ensure_valid_context(context)
 
-      return Unleash::FeatureToggle.disabled_variant unless self.enabled && am_enabled?(context, true)
+      return Unleash::FeatureToggle.disabled_variant unless self.enabled && am_enabled?(context)
       return Unleash::FeatureToggle.disabled_variant if sum_variant_defs_weights <= 0
 
       variant = variant_from_override_match(context) || variant_from_weights(context, resolve_stickiness)
@@ -57,7 +57,7 @@ module Unleash
     end
 
     # only check if it is enabled, do not do metrics
-    def am_enabled?(context, default_result)
+    def am_enabled?(context)
       result =
         if self.enabled
           self.strategies.empty? ||
@@ -65,10 +65,10 @@ module Unleash
               strategy_enabled?(s, context) && strategy_constraint_matches?(s, context)
             end
         else
-          default_result
+          false
         end
 
-      Unleash.logger.debug "Unleash::FeatureToggle (enabled:#{self.enabled} default_result:#{default_result} " \
+      Unleash.logger.debug "Unleash::FeatureToggle (enabled:#{self.enabled} " \
         "and Strategies combined with contraints returned #{result})"
 
       result

--- a/spec/unleash/client_specification_spec.rb
+++ b/spec/unleash/client_specification_spec.rb
@@ -8,7 +8,6 @@ RSpec.describe Unleash::Client do
   # load client spec
   SPECIFICATION_PATH = 'client-specification/specifications'.freeze
 
-  DEFAULT_RESULT = false
   DEFAULT_VARIANT = Unleash::Variant.new(name: 'unknown', enabled: false).freeze
 
   before do
@@ -41,7 +40,7 @@ RSpec.describe Unleash::Client do
               toggle = Unleash::FeatureToggle.new(test_toggle)
               context = Unleash::Context.new(test['context'])
 
-              toggle_result = toggle.is_enabled?(context, DEFAULT_RESULT)
+              toggle_result = toggle.is_enabled?(context)
 
               expect(toggle_result).to eq(test['expectedResult'])
             end

--- a/spec/unleash/feature_toggle_spec.rb
+++ b/spec/unleash/feature_toggle_spec.rb
@@ -28,14 +28,9 @@ RSpec.describe Unleash::FeatureToggle do
       )
     end
 
-    it 'should return true if enabled, and default is true' do
+    it 'should return true if enabled' do
       context = Unleash::Context.new(user_id: 1)
-      expect(feature_toggle.is_enabled?(context, true)).to be_truthy
-    end
-
-    it 'should return true if enabled, and default is false' do
-      context = Unleash::Context.new(user_id: 1)
-      expect(feature_toggle.is_enabled?(context, false)).to be_truthy
+      expect(feature_toggle.is_enabled?(context)).to be_truthy
     end
   end
 
@@ -51,14 +46,9 @@ RSpec.describe Unleash::FeatureToggle do
       )
     end
 
-    it 'should return false if disabled and default is false' do
+    it 'should return false if disabled' do
       context = Unleash::Context.new(user_id: 1)
-      expect(feature_toggle.is_enabled?(context, false)).to be_falsey
-    end
-
-    it 'should return true if disabled and default is true' do
-      context = Unleash::Context.new(user_id: 1)
-      expect(feature_toggle.is_enabled?(context, true)).to be_truthy
+      expect(feature_toggle.is_enabled?(context)).to be_falsey
     end
   end
 
@@ -81,24 +71,14 @@ RSpec.describe Unleash::FeatureToggle do
       )
     end
 
-    it 'should return true if enabled, user_id matched, and default is true' do
+    it 'should return true if enabled and user_id is matched' do
       context = Unleash::Context.new(user_id: "12345")
-      expect(feature_toggle.is_enabled?(context, true)).to be_truthy
+      expect(feature_toggle.is_enabled?(context)).to be_truthy
     end
 
-    it 'should return true if enabled, user_id matched, and default is false' do
-      context = Unleash::Context.new(user_id: "12345")
-      expect(feature_toggle.is_enabled?(context, false)).to be_truthy
-    end
-
-    it 'should return false if enabled, user_id unmatched, and default is true' do
+    it 'should return false if enabled and user_id is unmatched' do
       context = Unleash::Context.new(user_id: "54321")
-      expect(feature_toggle.is_enabled?(context, true)).to be_falsey
-    end
-
-    it 'should return false if enabled, user_id unmatched, and default is false' do
-      context = Unleash::Context.new(user_id: "54321")
-      expect(feature_toggle.is_enabled?(context, false)).to be_falsey
+      expect(feature_toggle.is_enabled?(context)).to be_falsey
     end
   end
 
@@ -121,24 +101,14 @@ RSpec.describe Unleash::FeatureToggle do
       )
     end
 
-    it 'should return false if disabled, user_id matched, and default is false' do
+    it 'should return false if disabled and user_id matched' do
       context = Unleash::Context.new(user_id: "12345")
-      expect(feature_toggle.is_enabled?(context, false)).to be_falsey
+      expect(feature_toggle.is_enabled?(context)).to be_falsey
     end
 
-    it 'should return false if disabled, user_id unmatched, and default is false' do
+    it 'should return false if disabled and user_id unmatched' do
       context = Unleash::Context.new(user_id: "54321")
-      expect(feature_toggle.is_enabled?(context, false)).to be_falsey
-    end
-
-    it 'should return true if disabled, user_id matched, and default is true' do
-      context = Unleash::Context.new(user_id: "12345")
-      expect(feature_toggle.is_enabled?(context, true)).to be_truthy
-    end
-
-    it 'should return true if disabled, user_id unmatched, and default is true' do
-      context = Unleash::Context.new(user_id: "54321")
-      expect(feature_toggle.is_enabled?(context, true)).to be_truthy
+      expect(feature_toggle.is_enabled?(context)).to be_falsey
     end
   end
 
@@ -473,22 +443,22 @@ RSpec.describe Unleash::FeatureToggle do
 
     it 'should return true if it matches all constraints' do
       context = Unleash::Context.new(user_id: "123", environment: "dev")
-      expect(feature_toggle.is_enabled?(context, true)).to be_truthy
+      expect(feature_toggle.is_enabled?(context)).to be_truthy
     end
 
     it 'should return false if it does not match all constraints (env)' do
       context = Unleash::Context.new(user_id: "123", environment: "prod")
-      expect(feature_toggle.is_enabled?(context, true)).to be_falsey
+      expect(feature_toggle.is_enabled?(context)).to be_falsey
     end
 
     it 'should return false if it does not match all constraints (user_id)' do
       context = Unleash::Context.new(user_id: "11", environment: "dev")
-      expect(feature_toggle.is_enabled?(context, true)).to be_falsey
+      expect(feature_toggle.is_enabled?(context)).to be_falsey
     end
 
     it 'should return false if it does not match any constraint (env and user_id)' do
       context = Unleash::Context.new(user_id: "11", environment: "prod")
-      expect(feature_toggle.is_enabled?(context, true)).to be_falsey
+      expect(feature_toggle.is_enabled?(context)).to be_falsey
     end
   end
 
@@ -519,12 +489,12 @@ RSpec.describe Unleash::FeatureToggle do
 
     it 'should return true if it matches the constraint' do
       context = Unleash::Context.new(user_id: "123", environment: "dev")
-      expect(feature_toggle.is_enabled?(context, true)).to be_truthy
+      expect(feature_toggle.is_enabled?(context)).to be_truthy
     end
 
     it 'should return false if it does not match the constraint' do
       context = Unleash::Context.new(user_id: "123", environment: "prod")
-      expect(feature_toggle.is_enabled?(context, true)).to be_falsey
+      expect(feature_toggle.is_enabled?(context)).to be_falsey
     end
   end
 


### PR DESCRIPTION
The incumbent behaviour of feature toggles when they are present but disabled, and the default value was set to true, seemed to be incorrect - it would resolve to true, using the default value, rather than the value of the existing toggle. This meant that, for example (in the case of using the default strategy), code like `UNLEASH.is_enabled?('my-feature-toggle', context, true)` will always resolve to true regardless of the value of the toggle itself.

It doesn't seem correct that code within the feature toggle resolution code was taking default values - if a feature toggle is present, the default value shouldn't be relevant, so far as I understand the intent behind specifying a default value.

This PR corrects the assertions made in the tests for feature toggles, and corrects the behaviour accordingly. Please feed back If I've misunderstood anything here!

I would note also that given systems may be relying on this behaviour, even accidentally, in their applications, acceptance of this PR is a potential major backwards compatibility break, and therefore I would suggest a new major version release.