### PR TITLE
Allow custom strategies

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ Argument | Description | Required? |  Type |  Default Value|
 `logger` | Specify a custom `Logger` class to handle logs for the Unleash client. | N | Class | `Logger.new(STDOUT)` |
 `log_level` | Change the log level for the `Logger` class. Constant from `Logger::Severity`. | N | Constant | `Logger::WARN` |
 `bootstrap_config` | Bootstrap config on how to loaded data on start-up. This is useful for loading large states on startup without (or before) hitting the network. | N | Unleash::Bootstrap::Configuration | `nil` |
+`strategies` | Strategies manager that holds all strategies and allows to add custom strategies | N | Unleash::Strategies | `Unleash::Strategies.new` |
 
 For a more in-depth look, please see `lib/unleash/configuration.rb`.
 
@@ -455,6 +456,27 @@ This client comes with the all the required strategies out of the box:
  * RemoteAddressStrategy
  * UnknownStrategy
  * UserWithIdStrategy
+
+## Custom Strategies
+
+Client allows to add [custom activation strategies](https://docs.getunleash.io/advanced/custom_activation_strategy) using configuration. 
+In order for strategy to work correctly it should support two methods `name` and `is_enabled?`
+
+```ruby
+class MyCustomStrategy
+  def name
+    'muCustomStrategy'
+  end
+  
+  def is_enabled?(params = {}, context = nil)
+    true
+  end
+end
+
+Unleash.configure do |config|
+  config.strategies.add(MyCustomStrategy.new)
+end
+```
 
 ## Development
 

--- a/lib/unleash.rb
+++ b/lib/unleash.rb
@@ -1,6 +1,7 @@
 require 'unleash/version'
 require 'unleash/configuration'
 require 'unleash/strategy/base'
+require 'unleash/strategies'
 require 'unleash/context'
 require 'unleash/client'
 require 'logger'

--- a/lib/unleash.rb
+++ b/lib/unleash.rb
@@ -1,25 +1,12 @@
 require 'unleash/version'
 require 'unleash/configuration'
-require 'unleash/strategy/base'
 require 'unleash/strategies'
 require 'unleash/context'
 require 'unleash/client'
 require 'logger'
 
-Gem.find_files('unleash/strategy/**/*.rb').each{ |path| require path unless path.end_with? '_spec.rb' }
-
 module Unleash
   TIME_RESOLUTION = 3
-
-  STRATEGIES = Unleash::Strategy.constants
-    .select{ |c| Unleash::Strategy.const_get(c).is_a? Class }
-    .reject{ |c| ['NotImplemented', 'Base'].include?(c.to_s) }
-    .map do |c|
-      lowered_c = c.to_s
-      lowered_c[0] = lowered_c[0].downcase
-      [lowered_c.to_sym, Object.const_get("Unleash::Strategy::#{c}").new]
-    end
-    .to_h
 
   class << self
     attr_accessor :configuration, :toggle_fetcher, :toggles, :toggle_metrics, :reporter, :logger

--- a/lib/unleash.rb
+++ b/lib/unleash.rb
@@ -33,4 +33,8 @@ module Unleash
     self.configuration.validate!
     self.configuration.refresh_backup_file!
   end
+
+  def self.strategies
+    self.configuration.strategies
+  end
 end

--- a/lib/unleash.rb
+++ b/lib/unleash.rb
@@ -12,9 +12,13 @@ module Unleash
     attr_accessor :configuration, :toggle_fetcher, :toggles, :toggle_metrics, :reporter, :logger
   end
 
+  self.configuration = Unleash::Configuration.new
+
+  # Deprecated: Use Unleash.configure to add custom strategies
+  STRATEGIES = self.configuration.strategies
+
   # Support for configuration via yield:
   def self.configure
-    self.configuration ||= Unleash::Configuration.new
     yield(configuration)
 
     self.configuration.validate!

--- a/lib/unleash/client.rb
+++ b/lib/unleash/client.rb
@@ -110,7 +110,7 @@ module Unleash
         'appName': Unleash.configuration.app_name,
         'instanceId': Unleash.configuration.instance_id,
         'sdkVersion': "unleash-client-ruby:" + Unleash::VERSION,
-        'strategies': Unleash::STRATEGIES.keys,
+        'strategies': Unleash.strategies.keys,
         'started': Time.now.iso8601(Unleash::TIME_RESOLUTION),
         'interval': Unleash.configuration.metrics_interval_in_millis
       }

--- a/lib/unleash/configuration.rb
+++ b/lib/unleash/configuration.rb
@@ -20,7 +20,8 @@ module Unleash
       :backup_file,
       :logger,
       :log_level,
-      :bootstrap_config
+      :bootstrap_config,
+      :strategies
 
     def initialize(opts = {})
       ensure_valid_opts(opts)
@@ -99,6 +100,7 @@ module Unleash
       self.backup_file      = nil
       self.log_level        = Logger::WARN
       self.bootstrap_config = nil
+      self.strategies       = Unleash::Strategies.new
 
       self.custom_http_headers = {}
     end

--- a/lib/unleash/feature_toggle.rb
+++ b/lib/unleash/feature_toggle.rb
@@ -75,7 +75,7 @@ module Unleash
     end
 
     def strategy_enabled?(strategy, context)
-      r = Unleash.strategies.fetch(strategy.name.to_sym).is_enabled?(strategy.params, context)
+      r = Unleash.strategies.fetch(strategy.name).is_enabled?(strategy.params, context)
       Unleash.logger.debug "Unleash::FeatureToggle.strategy_enabled? Strategy #{strategy.name} returned #{r} with context: #{context}"
       r
     end
@@ -130,7 +130,7 @@ module Unleash
 
     def initialize_strategies(params)
       params.fetch('strategies', [])
-        .select{ |s| s.has_key?('name') && Unleash.strategies.includes?(s['name'].to_sym) }
+        .select{ |s| s.has_key?('name') && Unleash.strategies.includes?(s['name']) }
         .map do |s|
           ActivationStrategy.new(
             s['name'],

--- a/lib/unleash/feature_toggle.rb
+++ b/lib/unleash/feature_toggle.rb
@@ -75,7 +75,7 @@ module Unleash
     end
 
     def strategy_enabled?(strategy, context)
-      r = Unleash::STRATEGIES.fetch(strategy.name.to_sym, :unknown).is_enabled?(strategy.params, context)
+      r = Unleash.strategies.fetch(strategy.name.to_sym).is_enabled?(strategy.params, context)
       Unleash.logger.debug "Unleash::FeatureToggle.strategy_enabled? Strategy #{strategy.name} returned #{r} with context: #{context}"
       r
     end
@@ -130,7 +130,7 @@ module Unleash
 
     def initialize_strategies(params)
       params.fetch('strategies', [])
-        .select{ |s| s.has_key?('name') && Unleash::STRATEGIES.has_key?(s['name'].to_sym) }
+        .select{ |s| s.has_key?('name') && Unleash.strategies.includes?(s['name'].to_sym) }
         .map do |s|
           ActivationStrategy.new(
             s['name'],

--- a/lib/unleash/strategies.rb
+++ b/lib/unleash/strategies.rb
@@ -1,5 +1,5 @@
 require 'unleash/strategy/base'
-Gem.find_files('unleash/strategy/**/*.rb').each{ |path| require path unless path.end_with? '_spec.rb' }
+Gem.find_files('unleash/strategy/**/*.rb').each{ |path| require path }
 
 module Unleash
   class Strategies

--- a/lib/unleash/strategies.rb
+++ b/lib/unleash/strategies.rb
@@ -7,10 +7,9 @@ module Unleash
       @strategies = Unleash::Strategy.constants
         .select{ |c| Unleash::Strategy.const_get(c).is_a? Class }
         .reject{ |c| ['NotImplemented', 'Base'].include?(c.to_s) }
-        .map do |c|
-        lowered_c = c.to_s
-        lowered_c[0] = lowered_c[0].downcase
-        [lowered_c.to_sym, Object.const_get("Unleash::Strategy::#{c}").new]
+        .map do |strategy_class|
+        strategy = Object.const_get("Unleash::Strategy::#{strategy_class}").new
+        [strategy.name, strategy]
       end.to_h
     end
 
@@ -19,11 +18,11 @@ module Unleash
     end
 
     def includes?(name)
-      @strategies.has_key?(name)
+      @strategies.has_key?(name.to_s)
     end
 
     def fetch(name)
-      raise Unleash::Strategy::NotImplemented, "Strategy is not implemented" unless (strategy = @strategies[name])
+      raise Unleash::Strategy::NotImplemented, "Strategy is not implemented" unless (strategy = @strategies[name.to_s])
 
       strategy
     end

--- a/lib/unleash/strategies.rb
+++ b/lib/unleash/strategies.rb
@@ -1,3 +1,6 @@
+require 'unleash/strategy/base'
+Gem.find_files('unleash/strategy/**/*.rb').each{ |path| require path unless path.end_with? '_spec.rb' }
+
 module Unleash
   class Strategies
     def initialize

--- a/lib/unleash/strategies.rb
+++ b/lib/unleash/strategies.rb
@@ -4,13 +4,8 @@ Gem.find_files('unleash/strategy/**/*.rb').each{ |path| require path }
 module Unleash
   class Strategies
     def initialize
-      @strategies = Unleash::Strategy.constants
-        .select{ |c| Unleash::Strategy.const_get(c).is_a? Class }
-        .reject{ |c| ['NotImplemented', 'Base'].include?(c.to_s) }
-        .map do |strategy_class|
-        strategy = Object.const_get("Unleash::Strategy::#{strategy_class}").new
-        [strategy.name, strategy]
-      end.to_h
+      @strategies = {}
+      DEFAULT_STRATEGIES.each{ |strategy_class| add(strategy_class.new) }
     end
 
     def keys
@@ -30,5 +25,16 @@ module Unleash
     def add(strategy)
       @strategies[strategy.name] = strategy
     end
+
+    DEFAULT_STRATEGIES = [
+      Unleash::Strategy::ApplicationHostname,
+      Unleash::Strategy::Default,
+      Unleash::Strategy::FlexibleRollout,
+      Unleash::Strategy::GradualRolloutRandom,
+      Unleash::Strategy::GradualRolloutSessionId,
+      Unleash::Strategy::GradualRolloutUserId,
+      Unleash::Strategy::RemoteAddress,
+      Unleash::Strategy::UserWithId
+    ].freeze
   end
 end

--- a/lib/unleash/strategies.rb
+++ b/lib/unleash/strategies.rb
@@ -26,6 +26,14 @@ module Unleash
       @strategies[strategy.name] = strategy
     end
 
+    def []=(key, strategy)
+      @strategies[key.to_s] = strategy
+    end
+
+    def [](key)
+      @strategies[key.to_s]
+    end
+
     DEFAULT_STRATEGIES = [
       Unleash::Strategy::ApplicationHostname,
       Unleash::Strategy::Default,

--- a/lib/unleash/strategies.rb
+++ b/lib/unleash/strategies.rb
@@ -26,5 +26,9 @@ module Unleash
 
       strategy
     end
+
+    def add(strategy)
+      @strategies[strategy.name] = strategy
+    end
   end
 end

--- a/lib/unleash/strategies.rb
+++ b/lib/unleash/strategies.rb
@@ -1,0 +1,28 @@
+module Unleash
+  class Strategies
+    def initialize
+      @strategies = Unleash::Strategy.constants
+        .select{ |c| Unleash::Strategy.const_get(c).is_a? Class }
+        .reject{ |c| ['NotImplemented', 'Base'].include?(c.to_s) }
+        .map do |c|
+        lowered_c = c.to_s
+        lowered_c[0] = lowered_c[0].downcase
+        [lowered_c.to_sym, Object.const_get("Unleash::Strategy::#{c}").new]
+      end.to_h
+    end
+
+    def keys
+      @strategies.keys
+    end
+
+    def includes?(name)
+      @strategies.has_key?(name)
+    end
+
+    def fetch(name)
+      raise Unleash::Strategy::NotImplemented, "Strategy is not implemented" unless (strategy = @strategies[name])
+
+      strategy
+    end
+  end
+end

--- a/spec/unleash/configuration_spec.rb
+++ b/spec/unleash/configuration_spec.rb
@@ -26,6 +26,8 @@ RSpec.describe Unleash do
       expect(config.backup_file).to eq(Dir.tmpdir + '/unleash--repo.json')
       expect(config.project_name).to be_nil
 
+      expect(config.strategies).to be_instance_of(Unleash::Strategies)
+
       expect{ config.validate! }.to raise_error(ArgumentError)
     end
 

--- a/spec/unleash/configuration_spec.rb
+++ b/spec/unleash/configuration_spec.rb
@@ -4,7 +4,7 @@ require "unleash/configuration"
 RSpec.describe Unleash do
   describe 'Configuration' do
     before do
-      Unleash.configuration = nil
+      Unleash.configuration = Unleash::Configuration.new
     end
 
     it "should have the correct defaults" do

--- a/spec/unleash/strategies_spec.rb
+++ b/spec/unleash/strategies_spec.rb
@@ -32,19 +32,70 @@ RSpec.describe Unleash::Strategies do
     end
   end
 
-  describe '#add' do
-    let(:custom_strategy) { instance_double(Unleash::Strategy::Base, name: 'test') }
+  describe '#[]' do
+    it 'returns available strategy' do
+      expect(strategies[:flexibleRollout]).to be_instance_of(Unleash::Strategy::FlexibleRollout)
+      expect(strategies['applicationHostname']).to be_instance_of(Unleash::Strategy::ApplicationHostname)
+    end
 
+    it 'returns nil when missing strategy' do
+      expect(strategies[:missing]).to be_nil
+    end
+  end
+
+  describe '#add' do
     before do
       strategies.add(custom_strategy)
     end
 
-    it 'returns custom strategy' do
-      expect(strategies.keys.sort).to eq(['applicationHostname', 'default', 'flexibleRollout', 'gradualRolloutRandom',
-                                          'gradualRolloutSessionId', 'gradualRolloutUserId', 'remoteAddress',
-                                          'test', 'userWithId'])
-      expect(strategies.includes?('test')).to be_truthy
-      expect(strategies.fetch(:test)).to eq(custom_strategy)
+    context 'when existing strategy is available' do
+      let(:custom_strategy) { instance_double(Unleash::Strategy::Base, name: 'applicationHostname') }
+
+      it 'overrides previous strategy strategy' do
+        expect(strategies.includes?('applicationHostname')).to be_truthy
+        expect(strategies.fetch(:applicationHostname)).to eq(custom_strategy)
+        expect(strategies.fetch('applicationHostname')).to eq(custom_strategy)
+      end
+    end
+
+    context 'when strategy is new' do
+      let(:custom_strategy) { instance_double(Unleash::Strategy::Base, name: 'test') }
+
+      it 'adds new strategy strategy' do
+        expect(strategies.includes?('test')).to be_truthy
+        expect(strategies.fetch(:test)).to eq(custom_strategy)
+        expect(strategies.fetch('test')).to eq(custom_strategy)
+      end
+    end
+  end
+
+  describe '#[]=' do
+    let(:custom_strategy) { instance_double(Unleash::Strategy::Base, name: 'strange name') }
+
+    context 'when existing strategy is available' do
+      let(:custom_strategy) { instance_double(Unleash::Strategy::Base, name: 'applicationHostname') }
+
+      before do
+        strategies[:applicationHostname] = custom_strategy
+      end
+
+      it 'overrides previous strategy strategy' do
+        expect(strategies.includes?('applicationHostname')).to be_truthy
+        expect(strategies.fetch(:applicationHostname)).to eq(custom_strategy)
+        expect(strategies.fetch('applicationHostname')).to eq(custom_strategy)
+      end
+    end
+
+    context 'when strategy is new' do
+      before do
+        strategies['test'] = custom_strategy
+      end
+
+      it 'adds new strategy strategy' do
+        expect(strategies.includes?('test')).to be_truthy
+        expect(strategies.fetch(:test)).to eq(custom_strategy)
+        expect(strategies.fetch('test')).to eq(custom_strategy)
+      end
     end
   end
 end

--- a/spec/unleash/strategies_spec.rb
+++ b/spec/unleash/strategies_spec.rb
@@ -31,4 +31,20 @@ RSpec.describe Unleash::Strategies do
       expect { strategies.fetch(:missing) }.to raise_error(Unleash::Strategy::NotImplemented, message)
     end
   end
+
+  describe '#add' do
+    let(:custom_strategy) { instance_double(Unleash::Strategy::Base, name: 'test') }
+
+    before do
+      strategies.add(custom_strategy)
+    end
+
+    it 'returns custom strategy' do
+      expect(strategies.keys.sort).to eq(['applicationHostname', 'default', 'flexibleRollout', 'gradualRolloutRandom',
+                                          'gradualRolloutSessionId', 'gradualRolloutUserId', 'remoteAddress',
+                                          'test', 'userWithId'])
+      expect(strategies.includes?('test')).to be_truthy
+      expect(strategies.fetch(:test)).to eq(custom_strategy)
+    end
+  end
 end

--- a/spec/unleash/strategies_spec.rb
+++ b/spec/unleash/strategies_spec.rb
@@ -1,0 +1,31 @@
+require "spec_helper"
+
+RSpec.describe Unleash::Strategies do
+  let(:strategies) { described_class.new }
+
+  it 'initialized with default strategies' do
+    expect(strategies.keys.sort).to eq([:applicationHostname, :default, :flexibleRollout, :gradualRolloutRandom,
+                                        :gradualRolloutSessionId, :gradualRolloutUserId, :remoteAddress, :userWithId])
+  end
+
+  describe '#includes?' do
+    it 'returns true for available strategy' do
+      expect(strategies.includes?(strategies.keys.sample)).to be_truthy
+    end
+
+    it 'returns false for missing strategy' do
+      expect(strategies.includes?(:missing)).to be_falsey
+    end
+  end
+
+  describe '#fetch' do
+    it 'returns available strategy' do
+      expect(strategies.fetch(:flexibleRollout)).to be_instance_of(Unleash::Strategy::FlexibleRollout)
+    end
+
+    it 'raising error when missing' do
+      message = 'Strategy is not implemented'
+      expect { strategies.fetch(:missing) }.to raise_error(Unleash::Strategy::NotImplemented, message)
+    end
+  end
+end

--- a/spec/unleash/strategies_spec.rb
+++ b/spec/unleash/strategies_spec.rb
@@ -4,13 +4,15 @@ RSpec.describe Unleash::Strategies do
   let(:strategies) { described_class.new }
 
   it 'initialized with default strategies' do
-    expect(strategies.keys.sort).to eq([:applicationHostname, :default, :flexibleRollout, :gradualRolloutRandom,
-                                        :gradualRolloutSessionId, :gradualRolloutUserId, :remoteAddress, :userWithId])
+    expect(strategies.keys.sort).to eq(['applicationHostname', 'default', 'flexibleRollout', 'gradualRolloutRandom',
+                                        'gradualRolloutSessionId', 'gradualRolloutUserId', 'remoteAddress',
+                                        'userWithId'])
   end
 
   describe '#includes?' do
     it 'returns true for available strategy' do
-      expect(strategies.includes?(strategies.keys.sample)).to be_truthy
+      expect(strategies.includes?('gradualRolloutRandom')).to be_truthy
+      expect(strategies.includes?(:userWithId)).to be_truthy
     end
 
     it 'returns false for missing strategy' do
@@ -21,6 +23,7 @@ RSpec.describe Unleash::Strategies do
   describe '#fetch' do
     it 'returns available strategy' do
       expect(strategies.fetch(:flexibleRollout)).to be_instance_of(Unleash::Strategy::FlexibleRollout)
+      expect(strategies.fetch('applicationHostname')).to be_instance_of(Unleash::Strategy::ApplicationHostname)
     end
 
     it 'raising error when missing' do

--- a/spec/unleash/strategies_spec.rb
+++ b/spec/unleash/strategies_spec.rb
@@ -3,10 +3,44 @@ require "spec_helper"
 RSpec.describe Unleash::Strategies do
   let(:strategies) { described_class.new }
 
-  it 'initialized with default strategies' do
-    expect(strategies.keys.sort).to eq(['applicationHostname', 'default', 'flexibleRollout', 'gradualRolloutRandom',
-                                        'gradualRolloutSessionId', 'gradualRolloutUserId', 'remoteAddress',
-                                        'userWithId'])
+  describe 'strategies registration' do
+    let(:default_strategies) do
+      ['applicationHostname', 'default', 'flexibleRollout', 'gradualRolloutRandom',
+       'gradualRolloutSessionId', 'gradualRolloutUserId', 'remoteAddress',
+       'userWithId']
+    end
+
+    context 'when no custom strategies are defined' do
+      it 'has default list' do
+        expect(strategies.keys.sort).to eq(default_strategies)
+      end
+    end
+
+    # This block testing previous way of loading strategies, when we dynamically picked up all classes
+    # defined under `Unleash::Strategy` module
+    context 'when custom strategy is defined' do
+      let(:custom_strategy) do
+        Class.new do
+          def name
+            'myCustomStrategy'
+          end
+        end
+      end
+
+      before do
+        # Define custom class
+        Unleash::Strategy.const_set("MyCustomStrategy", custom_strategy)
+      end
+
+      after do
+        # Remove custom class so it does not interfere with other tests
+        Unleash::Strategy.send(:remove_const, :MyCustomStrategy)
+      end
+
+      it 'includes custom strategy in default list' do
+        expect(strategies.keys.sort).to eq(default_strategies.concat(['myCustomStrategy']).sort)
+      end
+    end
   end
 
   describe '#includes?' do

--- a/spec/unleash_spec.rb
+++ b/spec/unleash_spec.rb
@@ -8,4 +8,21 @@ RSpec.describe Unleash do
   it "does something useful" do
     expect(false).to eq(false)
   end
+
+  context 'when configured' do
+    before do
+      Unleash.configure do |config|
+        config.app_name = 'rspec_test'
+        config.url = 'http://testurl/'
+      end
+    end
+
+    it 'has configuration' do
+      expect(described_class.configuration).to be_instance_of(Unleash::Configuration)
+    end
+
+    it 'proxies strategies to config' do
+      expect(described_class.strategies).to eq(Unleash.configuration.strategies)
+    end
+  end
 end


### PR DESCRIPTION
Other clients and proxy allows implementation and usage of [custom activation strategies](https://docs.getunleash.io/advanced/custom_activation_strategy). This pull request provides easy way for ruby client to be extend with those strategies. 

Previous state:
- Strategies constructed at runtime into a constant.
- Strategies have duplicated logic for strategy name (method, initialization code)
- Strategies matched by converting everything into symbol
- Strategies stored as hash and force clients to work with hash

Pull Request:
- Wraps strategies management mechanism into simple interface
- Using strategy `name` method as single source of identification
- Allows adding new strategies at runtime
- Changes strategy construction from reflection to simple list (default strategies are not changed so often to require magick)