### PR TITLE
Ensure backup file is properly closed.

### DIFF
--- a/lib/unleash/toggle_fetcher.rb
+++ b/lib/unleash/toggle_fetcher.rb
@@ -65,24 +65,20 @@ module Unleash
 
     def save!
       Unleash.logger.debug "Will save toggles to disk now"
-      begin
-        backup_file = Unleash.configuration.backup_file
-        backup_file_tmp = "#{backup_file}.tmp"
 
-        self.toggle_lock.synchronize do
-          file = File.open(backup_file_tmp, "w")
+      backup_file = Unleash.configuration.backup_file
+      backup_file_tmp = "#{backup_file}.tmp"
+
+      self.toggle_lock.synchronize do
+        File.open(backup_file_tmp, "w") do |file|
           file.write(self.toggle_cache.to_json)
-          file.close
-          File.rename(backup_file_tmp, backup_file)
         end
-      rescue StandardError => e
-        # This is not really the end of the world. Swallowing the exception.
-        Unleash.logger.error "Unable to save backup file. Exception thrown #{e.class}:'#{e}'"
-        Unleash.logger.error "stacktrace: #{e.backtrace}"
-      ensure
-        file&.close if defined?(file)
-        self.toggle_lock.unlock if self.toggle_lock.locked?
+        File.rename(backup_file_tmp, backup_file)
       end
+    rescue StandardError => e
+      # This is not really the end of the world. Swallowing the exception.
+      Unleash.logger.error "Unable to save backup file. Exception thrown #{e.class}:'#{e}'"
+      Unleash.logger.error "stacktrace: #{e.backtrace}"
     end
 
     private

--- a/spec/unleash/toggle_fetcher_spec.rb
+++ b/spec/unleash/toggle_fetcher_spec.rb
@@ -1,0 +1,55 @@
+require 'spec_helper'
+
+RSpec.describe Unleash::ToggleFetcher do
+  subject(:toggle_fetcher) { Unleash::ToggleFetcher.new }
+
+  describe '#save!' do
+    before do
+      Unleash.configure do |config|
+        config.url      = 'http://toggle-fetcher-test-url/'
+        config.app_name = 'toggle-fetcher-my-test-app'
+      end
+
+      fetcher_features = {
+        "version": 1,
+        "features": [
+          {
+            "name": "Feature.A",
+            "description": "Enabled toggle",
+            "enabled": true,
+            "strategies": [{ "name": "toggle-fetcher" }]
+          }
+        ]
+      }
+
+      WebMock.stub_request(:get, "http://toggle-fetcher-test-url/client/features")
+        .to_return(status: 200,
+                   body: fetcher_features.to_json,
+                   headers: {})
+
+      Unleash.logger = Unleash.configuration.logger
+    end
+
+    context 'when toggle_cache generation fails' do
+      before do
+        allow(toggle_fetcher).to receive(:toggle_cache).and_raise(StandardError)
+      end
+
+      it 'swallows the error' do
+        expect { toggle_fetcher.save! }.not_to raise_error
+      end
+    end
+
+    context 'when toggle_cache with content is saved' do
+      before do
+        toggle_fetcher.toggle_cache = { features: [] }
+      end
+
+      it 'creates a file with toggle_cache in JSON' do
+        toggle_fetcher.save!
+        expect(File.exist?(Unleash.configuration.backup_file)).to eq(true)
+        expect(File.read(Unleash.configuration.backup_file)).to eq('{"features":[]}')
+      end
+    end
+  end
+end


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## Reason
We introduced this excellent gem, in a project of ours and noticed these strange errors in the logs:
```
ToggleFetcher ERROR] : thread ToggleFetcher threw exception NoMethodError  (1/Infinity): 'undefined method `close' for <Rake::FileTask  => []>:Rake::FileTask

        file&.close if defined?(file)
            ^^^^^^^
```
It turned out that the file variable was out of scope for the ensure block in the `Unleash::ToggleFetcher#save!` and in this case it was referring to a DSL method in the rake gem.

https://github.com/ruby/rake/blob/881416e322d597e47e62935ef6a9dbaed934fbfc/lib/rake/dsl_definition.rb#L76

This revealed some problems when closing the file in the ToggleFetcher.

## About the changes
Changes the way the file is closed in `Unleash::ToggleFetcher#save!`.
The ensure block didn't previously close the file because the variable was out of scope.
We also removed the explicit call to `Mutex#unlock` because using `Mutex#synchronize` unlocks when exiting the given block. 
https://github.com/ruby/ruby/blob/42a0bed351979cb4a59c641fa5f03e49609561fd/thread_sync.c#L600

We also added some defaults in spec_helper.rb to make it easier to write tests.