### PR TITLE
Fix GitHub actions

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -2,6 +2,8 @@ name: CI
 
 on:
   push:
+    branches:
+      - master
   pull_request:
 
 jobs:

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -22,6 +22,8 @@ jobs:
           - 2.7
           - 2.6
           - 2.5
+    env:
+      slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
     steps:
       - uses: actions/checkout@v2
@@ -54,13 +56,13 @@ jobs:
           parallel: true
       - name: Notify Slack of pipeline completion
         uses: 8398a7/action-slack@v3
-        if: ${{ github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name }}
+        if: ${{ github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name && env.slack_webhook_url != '' }}
         with:
           status: ${{ job.status }}
           text: Built on ${{ matrix.os }} - Ruby ${{ matrix.ruby-version }}
           fields: repo,message,commit,author,action,eventName,ref,workflow,job,took
         env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_WEBHOOK_URL: ${{ env.slack_webhook_url }}
 
   finish:
     needs: test

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -35,6 +35,7 @@ jobs:
       - name: Download test cases
         run: git clone --depth 5 --branch v4.1.0 https://github.com/Unleash/client-specification.git client-specification
       - name: rubocop
+        if: ${{ matrix.ruby-version != '2.5' && matrix.ruby-version != 'jruby-9.2' }}
         uses: reviewdog/action-rubocop@v2
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Minor modification to github actions to make them compatible with forked repos and ruby 2.5

Unfortunately, I failed to find suitable version of rubocop via `reviewdog` action. That's why rubocop is disabled on old rubies. Technically - running rubocop on all versions is redundant as it's result depends on code, not runtime. 

As a suggestion, I can recommend splitting this into two jobs. One for static test on single ruby, another for matrix rspec testing.