### PR TITLE
Require spec_helper in the .rspec file

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,2 +1,3 @@
 --format documentation
 --color
+--require 'spec_helper'

--- a/spec/unleash/activation_strategy_spec.rb
+++ b/spec/unleash/activation_strategy_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 require 'unleash/constraint'
 
 RSpec.describe Unleash::ActivationStrategy do

--- a/spec/unleash/bootstrap/handler_spec.rb
+++ b/spec/unleash/bootstrap/handler_spec.rb
@@ -1,6 +1,5 @@
 require 'unleash/bootstrap/handler'
 require 'unleash/bootstrap/configuration'
-require "spec_helper"
 
 RSpec.describe Unleash::Bootstrap::Handler do
   Unleash.configure do |config|

--- a/spec/unleash/bootstrap/provider/from_file_spec.rb
+++ b/spec/unleash/bootstrap/provider/from_file_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 require 'rspec/json_expectations'
 require 'unleash/bootstrap/provider/from_file'
 require 'json'

--- a/spec/unleash/client_spec.rb
+++ b/spec/unleash/client_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 
 RSpec.describe Unleash::Client do
   it "Uses custom http headers when initializing client" do

--- a/spec/unleash/client_spec.rb
+++ b/spec/unleash/client_spec.rb
@@ -1,4 +1,3 @@
-
 RSpec.describe Unleash::Client do
   it "Uses custom http headers when initializing client" do
     WebMock.stub_request(:post, "http://test-url/client/register")

--- a/spec/unleash/client_specification_spec.rb
+++ b/spec/unleash/client_specification_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 require 'unleash'
 require 'unleash/client'
 require 'unleash/configuration'

--- a/spec/unleash/configuration_spec.rb
+++ b/spec/unleash/configuration_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "unleash/configuration"
 
 RSpec.describe Unleash do

--- a/spec/unleash/constraint_spec.rb
+++ b/spec/unleash/constraint_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 
 RSpec.describe Unleash::Constraint do
   before do

--- a/spec/unleash/constraint_spec.rb
+++ b/spec/unleash/constraint_spec.rb
@@ -1,4 +1,3 @@
-
 RSpec.describe Unleash::Constraint do
   before do
     Unleash.configuration = Unleash::Configuration.new

--- a/spec/unleash/context_spec.rb
+++ b/spec/unleash/context_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 require 'unleash/context'
 
 RSpec.describe Unleash::Context do

--- a/spec/unleash/metrics_reporter_spec.rb
+++ b/spec/unleash/metrics_reporter_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "rspec/json_expectations"
 
 RSpec.describe Unleash::MetricsReporter do

--- a/spec/unleash/metrics_spec.rb
+++ b/spec/unleash/metrics_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "rspec/json_expectations"
 
 RSpec.describe Unleash::Metrics do

--- a/spec/unleash/scheduled_executor_spec.rb
+++ b/spec/unleash/scheduled_executor_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 require 'securerandom'
 
 RSpec.describe Unleash::ScheduledExecutor do

--- a/spec/unleash/strategy/application_hostname_spec.rb
+++ b/spec/unleash/strategy/application_hostname_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "unleash/strategy/application_hostname"
 
 RSpec.describe Unleash::Strategy::ApplicationHostname do

--- a/spec/unleash/strategy/base_spec.rb
+++ b/spec/unleash/strategy/base_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "unleash/strategy/base"
 
 RSpec.describe Unleash::Strategy::Base do

--- a/spec/unleash/strategy/default_spec.rb
+++ b/spec/unleash/strategy/default_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "unleash/strategy/default"
 
 RSpec.describe Unleash::Strategy::Default do

--- a/spec/unleash/strategy/flexible_rollout_spec.rb
+++ b/spec/unleash/strategy/flexible_rollout_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 require 'unleash/strategy/flexible_rollout'
 
 RSpec.describe Unleash::Strategy::FlexibleRollout do

--- a/spec/unleash/strategy/gradual_rollout_random_spec.rb
+++ b/spec/unleash/strategy/gradual_rollout_random_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "unleash/strategy/gradual_rollout_random"
 
 RSpec.describe Unleash::Strategy::GradualRolloutRandom do

--- a/spec/unleash/strategy/gradual_rollout_sessionid_spec.rb
+++ b/spec/unleash/strategy/gradual_rollout_sessionid_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "unleash/strategy/gradual_rollout_sessionid"
 require "unleash/strategy/util"
 

--- a/spec/unleash/strategy/gradual_rollout_userid_spec.rb
+++ b/spec/unleash/strategy/gradual_rollout_userid_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "unleash/strategy/gradual_rollout_userid"
 
 RSpec.describe Unleash::Strategy::GradualRolloutUserId do

--- a/spec/unleash/strategy/remote_address_spec.rb
+++ b/spec/unleash/strategy/remote_address_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "unleash/strategy/remote_address"
 
 RSpec.describe Unleash::Strategy::RemoteAddress do

--- a/spec/unleash/strategy/user_with_id_spec.rb
+++ b/spec/unleash/strategy/user_with_id_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "unleash/strategy/user_with_id"
 require "unleash/context"
 

--- a/spec/unleash/strategy/util_spec.rb
+++ b/spec/unleash/strategy/util_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "unleash/strategy/util"
 
 RSpec.describe Unleash::Strategy::Util do

--- a/spec/unleash/toggle_fetcher_spec.rb
+++ b/spec/unleash/toggle_fetcher_spec.rb
@@ -1,4 +1,3 @@
-
 RSpec.describe Unleash::ToggleFetcher do
   subject(:toggle_fetcher) { Unleash::ToggleFetcher.new }
 

--- a/spec/unleash/toggle_fetcher_spec.rb
+++ b/spec/unleash/toggle_fetcher_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 
 RSpec.describe Unleash::ToggleFetcher do
   subject(:toggle_fetcher) { Unleash::ToggleFetcher.new }

--- a/spec/unleash/variant_override_spec.rb
+++ b/spec/unleash/variant_override_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 
 RSpec.describe Unleash::VariantOverride do
   context 'parameters correctly assigned in initialization'

--- a/spec/unleash/variant_override_spec.rb
+++ b/spec/unleash/variant_override_spec.rb
@@ -1,4 +1,3 @@
-
 RSpec.describe Unleash::VariantOverride do
   context 'parameters correctly assigned in initialization'
 

--- a/spec/unleash_spec.rb
+++ b/spec/unleash_spec.rb
@@ -1,4 +1,3 @@
-
 RSpec.describe Unleash do
   it "has a version number" do
     expect(Unleash::VERSION).not_to be nil

--- a/spec/unleash_spec.rb
+++ b/spec/unleash_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 
 RSpec.describe Unleash do
   it "has a version number" do


### PR DESCRIPTION
## About the changes
Require the spec_helper file globally when running tests so it's not required to be included first in every test file. This would be a first step towards implementing some defaults as discussed in https://github.com/Unleash/unleash-client-ruby/pull/97#discussion_r865787364

It also makes it easier to contribute changes because there is no need to know which files are required to be imported in the test context.

## Discussion points
Not every project uses this approach and it's more of a preference which method is used.