### PR TITLE
Update RuboCop version

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -34,6 +34,9 @@ Style/StringLiterals:
 Style/RedundantSelf:
   Enabled: false
 
+Style/OptionalBooleanParameter:
+  Enabled: false
+
 Style/SymbolArray:
   EnforcedStyle: brackets
 Style/WordArray:

--- a/lib/unleash/configuration.rb
+++ b/lib/unleash/configuration.rb
@@ -99,7 +99,7 @@ module Unleash
     end
 
     def initialize_default_logger
-      self.logger = Logger.new(STDOUT)
+      self.logger = Logger.new($stdout)
 
       # on default logger, use custom formatter that includes thread_name:
       self.logger.formatter = proc do |severity, datetime, _progname, msg|

--- a/lib/unleash/strategy/flexible_rollout.rb
+++ b/lib/unleash/strategy/flexible_rollout.rb
@@ -10,7 +10,7 @@ module Unleash
       # need: params['percentage']
       def is_enabled?(params = {}, context = nil)
         return false unless params.is_a?(Hash)
-        return false unless context.class.name == 'Unleash::Context'
+        return false unless context.instance_of?(Unleash::Context)
 
         stickiness = params.fetch('stickiness', 'default')
         stickiness_id = resolve_stickiness(stickiness, context)

--- a/lib/unleash/strategy/gradual_rollout_sessionid.rb
+++ b/lib/unleash/strategy/gradual_rollout_sessionid.rb
@@ -10,7 +10,7 @@ module Unleash
       # need: params['percentage'], params['groupId'], context.user_id,
       def is_enabled?(params = {}, context = nil)
         return false unless params.is_a?(Hash) && params.has_key?('percentage')
-        return false unless context.class.name == 'Unleash::Context'
+        return false unless context.instance_of?(Unleash::Context)
         return false if context.session_id.nil? || context.session_id.empty?
 
         percentage = Integer(params['percentage'] || 0)

--- a/lib/unleash/strategy/gradual_rollout_userid.rb
+++ b/lib/unleash/strategy/gradual_rollout_userid.rb
@@ -10,7 +10,7 @@ module Unleash
       # need: params['percentage'], params['groupId'], context.user_id,
       def is_enabled?(params = {}, context = nil, _constraints = [])
         return false unless params.is_a?(Hash) && params.has_key?('percentage')
-        return false unless context.class.name == 'Unleash::Context'
+        return false unless context.instance_of?(Unleash::Context)
         return false if context.user_id.nil? || context.user_id.empty?
 
         percentage = Integer(params['percentage'] || 0)

--- a/lib/unleash/strategy/remote_address.rb
+++ b/lib/unleash/strategy/remote_address.rb
@@ -11,7 +11,7 @@ module Unleash
       def is_enabled?(params = {}, context = nil)
         return false unless params.is_a?(Hash) && params.has_key?(PARAM)
         return false unless params.fetch(PARAM, nil).is_a? String
-        return false unless context.class.name == 'Unleash::Context'
+        return false unless context.instance_of?(Unleash::Context)
 
         remote_address = ipaddr_or_nil_from_str(context.remote_address)
 

--- a/lib/unleash/strategy/user_with_id.rb
+++ b/lib/unleash/strategy/user_with_id.rb
@@ -11,7 +11,7 @@ module Unleash
       def is_enabled?(params = {}, context = nil)
         return false unless params.is_a?(Hash) && params.has_key?(PARAM)
         return false unless params.fetch(PARAM, nil).is_a? String
-        return false unless context.class.name == 'Unleash::Context'
+        return false unless context.instance_of?(Unleash::Context)
 
         params[PARAM].split(",").map(&:strip).include?(context.user_id)
       end

--- a/lib/unleash/variant_definition.rb
+++ b/lib/unleash/variant_definition.rb
@@ -4,7 +4,7 @@ module Unleash
   class VariantDefinition
     attr_accessor :name, :weight, :payload, :overrides, :stickiness
 
-    def initialize(name, weight = 0, payload = nil, stickiness = nil, overrides = [])
+    def initialize(name, weight = 0, payload = nil, stickiness = nil, overrides = []) # rubocop:disable Metrics/ParameterLists
       self.name = name
       self.weight = weight
       self.payload = payload

--- a/lib/unleash/variant_override.rb
+++ b/lib/unleash/variant_override.rb
@@ -14,7 +14,7 @@ module Unleash
     end
 
     def matches_context?(context)
-      raise ArgumentError, 'context must be of class Unleash::Context' unless context.class.name == 'Unleash::Context'
+      raise ArgumentError, 'context must be of class Unleash::Context' unless context.instance_of?(Unleash::Context)
 
       context_value =
         case self.context_name

--- a/unleash-client.gemspec
+++ b/unleash-client.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec-json_expectations", "~> 2.2"
   spec.add_development_dependency "webmock", "~> 3.8"
 
-  spec.add_development_dependency "rubocop", "< 1.0.0"
+  spec.add_development_dependency "rubocop", "1.28.2"
   spec.add_development_dependency "simplecov", "~> 0.21.2"
   spec.add_development_dependency "simplecov-lcov", "~> 0.8.0"
 end

--- a/unleash-client.gemspec
+++ b/unleash-client.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec-json_expectations", "~> 2.2"
   spec.add_development_dependency "webmock", "~> 3.8"
 
-  spec.add_development_dependency "rubocop", "1.28.2"
+  spec.add_development_dependency "rubocop", "~> 1.28.2"
   spec.add_development_dependency "simplecov", "~> 0.21.2"
   spec.add_development_dependency "simplecov-lcov", "~> 0.8.0"
 end


### PR DESCRIPTION
## About the changes
Updates the RuboCop version to version 1.28.2. RuboCop 1.28 is the latest version to still support Ruby 2.5.
This is the version that was intended to be used but the build was broken and after it was fixed in https://github.com/Unleash/unleash-client-ruby/pull/101 we can now update the version and fix the RuboCop errors.

### Important files
* .rubocop.yml
* lib/unleash/variant_definition.rb
