### PR TITLE
Add dynamic headers support

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,8 +67,13 @@ If you need custom http headers that change during the lifetime of the client, a
 ```ruby
 Unleash.configure do |config|
   config.app_name            = 'my_ruby_app'
-  config.url                 = 'http://unleash.herokuapp.com/api'
-  config.custom_http_headers =  -> { {'Authorization': '<API token>'} }
+  config.url                 = 'https://unleash.herokuapp.com/api'
+  config.custom_http_headers =  proc do
+    {
+      'Authorization': '<API token>',
+      'X-Client-Request-Time': Time.now.iso8601
+    }
+  end
 end
 ```
 

--- a/README.md
+++ b/README.md
@@ -61,6 +61,17 @@ or instantiate the client with the valid configuration:
 UNLEASH = Unleash::Client.new(url: 'http://unleash.herokuapp.com/api', app_name: 'my_ruby_app', custom_http_headers: {'Authorization': '<API token>'})
 ```
 
+## Dynamic custom HTTP headers
+If you need custom http headers that change during the lifetime of the client, a the `custom_http_headers` can be given as a `Proc`.
+
+```ruby
+Unleash.configure do |config|
+  config.app_name            = 'my_ruby_app'
+  config.url                 = 'http://unleash.herokuapp.com/api'
+  config.custom_http_headers =  -> { {'Authorization': '<API token>'} }
+end
+```
+
 #### List of Arguments
 
 Argument | Description | Required? |  Type |  Default Value|
@@ -74,7 +85,7 @@ Argument | Description | Required? |  Type |  Default Value|
 `metrics_interval` | How often the unleash client should send metrics to server. | N | Integer | 60 |
 `disable_client` | Disables all communication with the Unleash server, effectively taking it *offline*. If set, `is_enabled?` will always answer with the `default_value` and configuration validation is skipped. Defeats the entire purpose of using unleash, but can be useful in when running tests. | N | Boolean | `false` |
 `disable_metrics` | Disables sending metrics to Unleash server. | N | Boolean | `false` |
-`custom_http_headers` | Custom headers to send to Unleash. As of Unleash v4.0.0, the `Authorization` header is required. For example: `{'Authorization': '<API token>'}` | N | Hash | {} |
+`custom_http_headers` | Custom headers to send to Unleash. As of Unleash v4.0.0, the `Authorization` header is required. For example: `{'Authorization': '<API token>'}` | N | Hash/Proc | {} |
 `timeout` | How long to wait for the connection to be established or wait in reading state (open_timeout/read_timeout) | N | Integer | 30 |
 `retry_limit` | How many consecutive failures in connecting to the Unleash server are allowed before giving up. The default is to retry indefinitely. | N | Float::INFINITY | 5 |
 `backup_file` | Filename to store the last known state from the Unleash server. Best to not change this from the default. | N | String | `Dir.tmpdir + "/unleash-#{app_name}-repo.json` |

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ UNLEASH = Unleash::Client.new(url: 'http://unleash.herokuapp.com/api', app_name:
 ```
 
 ## Dynamic custom HTTP headers
-If you need custom http headers that change during the lifetime of the client, a the `custom_http_headers` can be given as a `Proc`.
+If you need custom HTTP headers that change during the lifetime of the client, the `custom_http_headers` can be given as a `Proc`.
 
 ```ruby
 Unleash.configure do |config|

--- a/lib/unleash/configuration.rb
+++ b/lib/unleash/configuration.rb
@@ -52,7 +52,7 @@ module Unleash
       {
         'UNLEASH-INSTANCEID' => self.instance_id,
         'UNLEASH-APPNAME' => self.app_name
-      }.merge(generate_custom_http_headers)
+      }.merge!(generate_custom_http_headers)
     end
 
     def fetch_toggles_uri

--- a/lib/unleash/configuration.rb
+++ b/lib/unleash/configuration.rb
@@ -40,7 +40,7 @@ module Unleash
 
       raise ArgumentError, "URL and app_name are required parameters." if self.app_name.nil? || self.url.nil?
       unless self.custom_http_headers.is_a?(Hash) || self.custom_http_headers.respond_to?(:call)
-        raise ArgumentError, "custom_http_headers must be a hash."
+        raise ArgumentError, "custom_http_headers must be a Hash or a Proc."
       end
     end
 

--- a/lib/unleash/configuration.rb
+++ b/lib/unleash/configuration.rb
@@ -23,7 +23,6 @@ module Unleash
       :bootstrap_config
 
     def initialize(opts = {})
-      ensure_valid_opts(opts)
       set_defaults
 
       initialize_default_logger if opts[:logger].nil?
@@ -40,7 +39,9 @@ module Unleash
       return if self.disable_client
 
       raise ArgumentError, "URL and app_name are required parameters." if self.app_name.nil? || self.url.nil?
-      raise ArgumentError, "custom_http_headers must be a hash." unless self.custom_http_headers.is_a?(Hash)
+      unless self.custom_http_headers.is_a?(Hash) || self.custom_http_headers.respond_to?(:call)
+        raise ArgumentError, "custom_http_headers must be a hash."
+      end
     end
 
     def refresh_backup_file!
@@ -51,7 +52,7 @@ module Unleash
       {
         'UNLEASH-INSTANCEID' => self.instance_id,
         'UNLEASH-APPNAME' => self.app_name
-      }.merge(custom_http_headers.dup)
+      }.merge(generate_custom_http_headers)
     end
 
     def fetch_toggles_uri
@@ -77,12 +78,6 @@ module Unleash
     end
 
     private
-
-    def ensure_valid_opts(opts)
-      unless opts[:custom_http_headers].is_a?(Hash) || opts[:custom_http_headers].nil?
-        raise ArgumentError, "custom_http_headers must be a hash."
-      end
-    end
 
     def set_defaults
       self.app_name         = nil
@@ -116,6 +111,14 @@ module Unleash
     def merge(opts)
       opts.each_pair{ |opt, val| set_option(opt, val) }
       self
+    end
+
+    def generate_custom_http_headers
+      if self.custom_http_headers.respond_to?(:call)
+        self.custom_http_headers.call
+      else
+        self.custom_http_headers
+      end
     end
 
     def set_option(opt, val)

--- a/spec/unleash/configuration_spec.rb
+++ b/spec/unleash/configuration_spec.rb
@@ -107,35 +107,47 @@ RSpec.describe Unleash do
       Unleash.configure do |config|
         config.url      = 'http://test-url/'
         config.app_name = 'my-test-app'
-        config.custom_http_headers = { 'X-API-KEY' => '123' }
+        config.custom_http_headers = { 'X-API-KEY': '123' }
       end
       expect{ Unleash.configuration.validate! }.not_to raise_error
-      expect(Unleash.configuration.custom_http_headers).to eq({ 'X-API-KEY' => '123' })
-      expect(Unleash.configuration.http_headers).to include({ 'X-API-KEY' => '123' })
+      expect(Unleash.configuration.custom_http_headers).to eq({ 'X-API-KEY': '123' })
     end
 
     it "should allow hashes for custom_http_headers via new client" do
       config = Unleash::Configuration.new(
         url: 'https://testurl/api',
         app_name: 'test-app',
-        custom_http_headers: { 'X-API-KEY' => '123' }
+        custom_http_headers: { 'X-API-KEY': '123' }
       )
 
       expect{ config.validate! }.not_to raise_error
-      expect(config.custom_http_headers).to eq({ 'X-API-KEY' => '123' })
-      expect(config.http_headers).to eq('X-API-KEY' => '123', 'UNLEASH-APPNAME' => 'test-app', 'UNLEASH-INSTANCEID' => config.instance_id)
+      expect(config.custom_http_headers).to include({ 'X-API-KEY': '123' })
+      expect(config.http_headers).to include({ 'UNLEASH-APPNAME' => 'test-app' })
+      expect(config.http_headers).to include('UNLEASH-INSTANCEID')
     end
 
     it "should allow lambdas and procs for custom_https_headers via new client" do
+      proc = proc do
+        { 'X-API-KEY' => '123' }
+      end
+      allow(proc).to receive(:call).and_call_original
+
       config = Unleash::Configuration.new(
         url: 'https://testurl/api',
         app_name: 'test-app',
-        custom_http_headers: -> { { 'X-API-KEY' => '123' } }
+        custom_http_headers: proc
       )
 
       expect{ config.validate! }.not_to raise_error
       expect(config.custom_http_headers).to be_a(Proc)
-      expect(config.http_headers).to eq('X-API-KEY' => '123', 'UNLEASH-APPNAME' => 'test-app', 'UNLEASH-INSTANCEID' => config.instance_id)
+      expect(config.http_headers).to eq(
+        {
+          'X-API-KEY' => '123',
+          'UNLEASH-APPNAME' => 'test-app',
+          'UNLEASH-INSTANCEID' => config.instance_id
+        }
+      )
+      expect(proc).to have_received(:call)
     end
 
     it "should not accept invalid custom_http_headers via yield" do

--- a/spec/unleash/configuration_spec.rb
+++ b/spec/unleash/configuration_spec.rb
@@ -123,9 +123,7 @@ RSpec.describe Unleash do
 
       expect{ config.validate! }.not_to raise_error
       expect(config.custom_http_headers).to eq({ 'X-API-KEY' => '123' })
-      expect(config.http_headers).to include({ 'X-API-KEY' => '123' })
-      expect(config.http_headers).to include({ 'UNLEASH-APPNAME' => 'test-app' })
-      expect(config.http_headers).to include('UNLEASH-INSTANCEID')
+      expect(config.http_headers).to eq('X-API-KEY' => '123', 'UNLEASH-APPNAME' => 'test-app', 'UNLEASH-INSTANCEID' => config.instance_id)
     end
 
     it "should allow lambdas and procs for custom_https_headers via new client" do
@@ -137,9 +135,7 @@ RSpec.describe Unleash do
 
       expect{ config.validate! }.not_to raise_error
       expect(config.custom_http_headers).to be_a(Proc)
-      expect(config.http_headers).to include({ 'X-API-KEY' => '123' })
-      expect(config.http_headers).to include({ 'UNLEASH-APPNAME' => 'test-app' })
-      expect(config.http_headers).to include('UNLEASH-INSTANCEID')
+      expect(config.http_headers).to eq('X-API-KEY' => '123', 'UNLEASH-APPNAME' => 'test-app', 'UNLEASH-INSTANCEID' => config.instance_id)
     end
 
     it "should not accept invalid custom_http_headers via yield" do
@@ -149,7 +145,7 @@ RSpec.describe Unleash do
           config.app_name = 'my-test-app'
           config.custom_http_headers = 123.456
         end
-      end.to raise_error(ArgumentError)
+      end.to raise_error(ArgumentError, "custom_http_headers must be a Hash or a Proc.")
     end
 
     it "should not accept invalid custom_http_headers via new client" do

--- a/spec/unleash/configuration_spec.rb
+++ b/spec/unleash/configuration_spec.rb
@@ -107,21 +107,37 @@ RSpec.describe Unleash do
       Unleash.configure do |config|
         config.url      = 'http://test-url/'
         config.app_name = 'my-test-app'
-        config.custom_http_headers = { 'X-API-KEY': '123' }
+        config.custom_http_headers = { 'X-API-KEY' => '123' }
       end
       expect{ Unleash.configuration.validate! }.not_to raise_error
-      expect(Unleash.configuration.custom_http_headers).to eq({ 'X-API-KEY': '123' })
+      expect(Unleash.configuration.custom_http_headers).to eq({ 'X-API-KEY' => '123' })
+      expect(Unleash.configuration.http_headers).to include({ 'X-API-KEY' => '123' })
     end
 
     it "should allow hashes for custom_http_headers via new client" do
       config = Unleash::Configuration.new(
         url: 'https://testurl/api',
         app_name: 'test-app',
-        custom_http_headers: { 'X-API-KEY': '123' }
+        custom_http_headers: { 'X-API-KEY' => '123' }
       )
 
       expect{ config.validate! }.not_to raise_error
-      expect(config.custom_http_headers).to include({ 'X-API-KEY': '123' })
+      expect(config.custom_http_headers).to eq({ 'X-API-KEY' => '123' })
+      expect(config.http_headers).to include({ 'X-API-KEY' => '123' })
+      expect(config.http_headers).to include({ 'UNLEASH-APPNAME' => 'test-app' })
+      expect(config.http_headers).to include('UNLEASH-INSTANCEID')
+    end
+
+    it "should allow lambdas and procs for custom_https_headers via new client" do
+      config = Unleash::Configuration.new(
+        url: 'https://testurl/api',
+        app_name: 'test-app',
+        custom_http_headers: -> { { 'X-API-KEY' => '123' } }
+      )
+
+      expect{ config.validate! }.not_to raise_error
+      expect(config.custom_http_headers).to be_a(Proc)
+      expect(config.http_headers).to include({ 'X-API-KEY' => '123' })
       expect(config.http_headers).to include({ 'UNLEASH-APPNAME' => 'test-app' })
       expect(config.http_headers).to include('UNLEASH-INSTANCEID')
     end

--- a/spec/unleash/configuration_spec.rb
+++ b/spec/unleash/configuration_spec.rb
@@ -127,15 +127,15 @@ RSpec.describe Unleash do
     end
 
     it "should allow lambdas and procs for custom_https_headers via new client" do
-      proc = proc do
+      custom_headers_proc = proc do
         { 'X-API-KEY' => '123' }
       end
-      allow(proc).to receive(:call).and_call_original
+      allow(custom_headers_proc).to receive(:call).and_call_original
 
       config = Unleash::Configuration.new(
         url: 'https://testurl/api',
         app_name: 'test-app',
-        custom_http_headers: proc
+        custom_http_headers: custom_headers_proc
       )
 
       expect{ config.validate! }.not_to raise_error
@@ -147,7 +147,7 @@ RSpec.describe Unleash do
           'UNLEASH-INSTANCEID' => config.instance_id
         }
       )
-      expect(proc).to have_received(:call)
+      expect(custom_headers_proc).to have_received(:call)
     end
 
     it "should not accept invalid custom_http_headers via yield" do

--- a/spec/unleash/configuration_spec.rb
+++ b/spec/unleash/configuration_spec.rb
@@ -147,7 +147,7 @@ RSpec.describe Unleash do
           'UNLEASH-INSTANCEID' => config.instance_id
         }
       )
-      expect(custom_headers_proc).to have_received(:call)
+      expect(custom_headers_proc).to have_received(:call).exactly(1).times
     end
 
     it "should not accept invalid custom_http_headers via yield" do


### PR DESCRIPTION
## About the changes
Add support for dynamic `custom_http_headers` by allowing passing a Proc/Lambda as the configuration.

We also removed and unnecessary duplication from the `http_headers` method.

Closes #83 

## Discussion points
We removed a redundant method `ensure_valid_opts` that was called in the constructor. This method was also out of sync with the `Configuration#validate!` by allowing nil. We ensured that `Configuration#validate!` was called in the places where it's needed before removing this method.