### PR TITLE
feat: implement global segments

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Install dependencies
         run: bundle install
       - name: Download test cases
-        run: git clone --depth 5 --branch v4.1.0 https://github.com/Unleash/client-specification.git client-specification
+        run: git clone --depth 5 --branch v4.2.2 https://github.com/Unleash/client-specification.git client-specification
       - name: Run tests
         run: bundle exec rake
         env:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -9,7 +9,7 @@ Naming/PredicateName:
 
 
 Metrics/ClassLength:
-  Max: 125
+  Max: 130
 Layout/LineLength:
   Max: 140
 Metrics/MethodLength:

--- a/lib/unleash.rb
+++ b/lib/unleash.rb
@@ -21,7 +21,7 @@ module Unleash
     .to_h
 
   class << self
-    attr_accessor :configuration, :toggle_fetcher, :toggles, :toggle_metrics, :reporter, :logger
+    attr_accessor :configuration, :toggle_fetcher, :toggles, :toggle_metrics, :reporter, :segment_cache, :logger
   end
 
   # Support for configuration via yield:

--- a/lib/unleash/activation_strategy.rb
+++ b/lib/unleash/activation_strategy.rb
@@ -1,9 +1,10 @@
 module Unleash
   class ActivationStrategy
-    attr_accessor :name, :params, :constraints
+    attr_accessor :name, :params, :constraints, :disabled
 
     def initialize(name, params, constraints = [])
       self.name = name
+      self.disabled = false
 
       if params.is_a?(Hash)
         self.params = params
@@ -18,6 +19,7 @@ module Unleash
         self.constraints = constraints
       else
         Unleash.logger.warn "Invalid constraints provided for ActivationStrategy (contraints: #{constraints})"
+        self.disabled = true
         self.constraints = []
       end
     end

--- a/lib/unleash/client.rb
+++ b/lib/unleash/client.rb
@@ -45,7 +45,7 @@ module Unleash
         return default_value
       end
 
-      toggle = Unleash::FeatureToggle.new(toggle_as_hash)
+      toggle = Unleash::FeatureToggle.new(toggle_as_hash, Unleash&.segment_cache)
 
       toggle.is_enabled?(context)
     end

--- a/lib/unleash/configuration.rb
+++ b/lib/unleash/configuration.rb
@@ -51,7 +51,8 @@ module Unleash
     def http_headers
       {
         'UNLEASH-INSTANCEID' => self.instance_id,
-        'UNLEASH-APPNAME' => self.app_name
+        'UNLEASH-APPNAME' => self.app_name,
+        'Unleash-Client-Spec' => '4.2.2'
       }.merge!(generate_custom_http_headers)
     end
 

--- a/spec/unleash/client_specification_spec.rb
+++ b/spec/unleash/client_specification_spec.rb
@@ -30,6 +30,7 @@ RSpec.describe Unleash::Client do
           tests = current_test_set.fetch('tests', [])
           state = current_test_set.fetch('state', {})
           state_features = state.fetch('features', [])
+          state_segments = state.fetch('segments', []).map{ |segment| [segment["id"], segment] }.to_h
 
           let(:unleash_toggles) { state_features }
 
@@ -37,7 +38,7 @@ RSpec.describe Unleash::Client do
             it "test that #{test['description']}" do
               test_toggle = unleash_toggles.select{ |t| t.fetch('name', '') == test.fetch('toggleName') }.first
 
-              toggle = Unleash::FeatureToggle.new(test_toggle)
+              toggle = Unleash::FeatureToggle.new(test_toggle, state_segments)
               context = Unleash::Context.new(test['context'])
 
               toggle_result = toggle.is_enabled?(context)
@@ -51,7 +52,7 @@ RSpec.describe Unleash::Client do
             it "test that #{test['description']}" do
               test_toggle = unleash_toggles.select{ |t| t.fetch('name', '') == test.fetch('toggleName') }.first
 
-              toggle = Unleash::FeatureToggle.new(test_toggle)
+              toggle = Unleash::FeatureToggle.new(test_toggle, state_segments)
               context = Unleash::Context.new(test['context'])
 
               variant = toggle.get_variant(context, DEFAULT_VARIANT)

--- a/spec/unleash/configuration_spec.rb
+++ b/spec/unleash/configuration_spec.rb
@@ -144,7 +144,8 @@ RSpec.describe Unleash do
         {
           'X-API-KEY' => '123',
           'UNLEASH-APPNAME' => 'test-app',
-          'UNLEASH-INSTANCEID' => config.instance_id
+          'UNLEASH-INSTANCEID' => config.instance_id,
+          'Unleash-Client-Spec' => '4.2.2'
         }
       )
       expect(custom_headers_proc).to have_received(:call).exactly(1).times

--- a/spec/unleash/toggle_fetcher_spec.rb
+++ b/spec/unleash/toggle_fetcher_spec.rb
@@ -19,7 +19,28 @@ RSpec.describe Unleash::ToggleFetcher do
           "enabled": true,
           "strategies": [{ "name": "toggle-fetcher" }]
         }
+      ],
+      "segments": [
+        {
+          "id": 1,
+          "name": "test-segment",
+          "description": "test-segment",
+          "constraints": [
+            {
+              "values": [
+                "7"
+              ],
+              "inverted": false,
+              "operator": "IN",
+              "contextName": "test",
+              "caseInsensitive": false
+            }
+          ],
+          "createdBy": "admin",
+          "createdAt": "2022-09-02T00:00:00.000Z"
+        }
       ]
+
     }
 
     WebMock.stub_request(:get, "http://toggle-fetcher-test-url/client/features")
@@ -83,6 +104,28 @@ RSpec.describe Unleash::ToggleFetcher do
 
       it 'returns an empty toggle_cache' do
         expect(toggle_fetcher.toggle_cache).to eq(nil)
+      end
+    end
+
+    context 'segments are present' do
+      it 'loads a segement map correctly' do
+        expect(toggle_fetcher.toggle_cache["segments"].count).to eq 1
+      end
+    end
+
+    context 'segments are not present' do
+      before do
+        WebMock.stub_request(:get, "http://toggle-fetcher-test-url/client/features")
+          .to_return(status: 200,
+                     body: {
+                       "version": 1,
+                       "features": []
+                     }.to_json,
+                     headers: {})
+      end
+
+      it 'loads an empty segment map' do
+        expect(toggle_fetcher.toggle_cache["segments"].count).to eq 0
       end
     end
   end


### PR DESCRIPTION
This implements global segments as per issue #112. There is one major deviation from the way this is implemented in other SDKs, this doesn't use a lazy generator, this is because this SDK doesn't cache computation as aggressively as the other SDKs.

Most of the tests are done through the client specifications but there's also some failing tests here, these aren't caused by this PR, but by upgrading the client specs. There's another PR incoming to fix that. 