### PR TITLE
fix: support int context in set comparison

### DIFF
--- a/lib/unleash/constraint.rb
+++ b/lib/unleash/constraint.rb
@@ -1,12 +1,11 @@
 require 'date'
-
 module Unleash
   class Constraint
     attr_accessor :context_name, :operator, :value, :inverted, :case_insensitive
 
     OPERATORS = {
-      IN: ->(context_v, constraint_v){ constraint_v.include? context_v },
-      NOT_IN: ->(context_v, constraint_v){ !constraint_v.include? context_v },
+      IN: ->(context_v, constraint_v){ constraint_v.include? context_v.to_s },
+      NOT_IN: ->(context_v, constraint_v){ !constraint_v.include? context_v.to_s },
       STR_STARTS_WITH: ->(context_v, constraint_v){ constraint_v.any?{ |v| context_v.start_with? v } },
       STR_ENDS_WITH: ->(context_v, constraint_v){ constraint_v.any?{ |v| context_v.end_with? v } },
       STR_CONTAINS: ->(context_v, constraint_v){ constraint_v.any?{ |v| context_v.include? v } },

--- a/spec/unleash/constraint_spec.rb
+++ b/spec/unleash/constraint_spec.rb
@@ -71,6 +71,24 @@ RSpec.describe Unleash::Constraint do
       expect(constraint.matches_context?(context)).to be true
     end
 
+    it 'matches based on user_id IN/NOT_IN user_id with user_id as int' do
+      context_params = {
+        user_id: 123
+      }
+      context = Unleash::Context.new(context_params)
+      constraint = Unleash::Constraint.new('user_id', 'IN', ['123', '456'])
+      expect(constraint.matches_context?(context)).to be true
+
+      constraint = Unleash::Constraint.new('user_id', 'IN', ['456', '789'])
+      expect(constraint.matches_context?(context)).to be false
+
+      constraint = Unleash::Constraint.new('user_id', 'NOT_IN', ['123', '456'])
+      expect(constraint.matches_context?(context)).to be false
+
+      constraint = Unleash::Constraint.new('user_id', 'NOT_IN', ['456', '789'])
+      expect(constraint.matches_context?(context)).to be true
+    end
+
     it 'matches based on property STR_STARTS_WITH value' do
       context_params = {
         properties: {


### PR DESCRIPTION
This makes it possible to have int values in context and compare it to sets from unleash which are strings.
