### PR TITLE
Fixes constructor

### DIFF
--- a/lib/unleash/client.rb
+++ b/lib/unleash/client.rb
@@ -12,7 +12,7 @@ module Unleash
     attr_accessor :fetcher_scheduled_executor, :metrics_scheduled_executor
 
     def initialize(*opts)
-      Unleash.configuration ||= Unleash::Configuration.new(*opts)
+      Unleash.configuration = Unleash::Configuration.new(*opts) unless opts.empty?
       Unleash.configuration.validate!
 
       Unleash.logger = Unleash.configuration.logger.clone


### PR DESCRIPTION
This pr makes initiating unleash like this work again:
```

@unleash = Unleash::Client.new(
  url: 'https://unleash.herokuapp.com/api',
  custom_http_headers: { 'Authorization': '943ca9171e2c884c545c5d82417a655fb77cec970cc3b78a8ff87f4406b495d0' },
  app_name: 'simple-test',
  instance_id: 'local-test-cli',
  refresh_interval: 2,
  metrics_interval: 2,
  retry_limit: 2
)
```