### PR TITLE
fix: add possibility to passing user_id as integer

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -22,7 +22,7 @@ Metrics/BlockLength:
 Metrics/AbcSize:
   Max: 30
 Metrics/CyclomaticComplexity:
-  Max: 9
+  Max: 10
 Metrics/PerceivedComplexity:
   Max: 10
 

--- a/lib/unleash/context.rb
+++ b/lib/unleash/context.rb
@@ -9,7 +9,7 @@ module Unleash
 
       self.app_name    = value_for('appName', params, Unleash&.configuration&.app_name)
       self.environment = value_for('environment', params, Unleash&.configuration&.environment || 'default')
-      self.user_id     = value_for('userId', params)
+      self.user_id     = value_for('userId', params)&.to_s
       self.session_id  = value_for('sessionId', params)
       self.remote_address = value_for('remoteAddress', params)
       self.current_time = value_for('currentTime', params, Time.now.utc.iso8601.to_s)

--- a/spec/unleash/client_spec.rb
+++ b/spec/unleash/client_spec.rb
@@ -409,8 +409,10 @@ RSpec.describe Unleash::Client do
 
   it "should yield correctly to block when using if_enabled" do
     unleash_client = Unleash::Client.new
+    cont = Unleash::Context.new(user_id: 1)
 
     expect{ |b| unleash_client.if_enabled('any_feature', {}, true, &b).to yield_with_no_args }
+    expect{ |b| unleash_client.if_enabled('any_feature', cont, true, &b).to yield_with_no_args }
     expect{ |b| unleash_client.if_enabled('any_feature', {}, false, &b).not_to yield_with_no_args }
   end
 

--- a/spec/unleash/strategy/user_with_id_spec.rb
+++ b/spec/unleash/strategy/user_with_id_spec.rb
@@ -4,35 +4,58 @@ require "unleash/context"
 RSpec.describe Unleash::Strategy::UserWithId do
   describe '#is_enabled?' do
     let(:strategy) { Unleash::Strategy::UserWithId.new }
-    let(:unleash_context) { Unleash::Context.new({ 'userId' => 'bob' }) }
 
-    it 'should be enabled with correct params' do
-      expect(strategy.is_enabled?({ 'userIds' => 'alice,bob,carol,dave' }, unleash_context)).to be_truthy
+    context 'with string params' do
+      let(:unleash_context) { Unleash::Context.new({ 'userId' => 'bob' }) }
 
-      unleash_context2 = Unleash::Context.new
-      unleash_context2.user_id = 'alice'
-      expect(strategy.is_enabled?({ 'userIds' => 'alice,bob,carol,dave' }, unleash_context2)).to be_truthy
+      it 'should be enabled with correct params' do
+        expect(strategy.is_enabled?({ 'userIds' => 'alice,bob,carol,dave' }, unleash_context)).to be_truthy
+
+        unleash_context2 = Unleash::Context.new
+        unleash_context2.user_id = 'alice'
+        expect(strategy.is_enabled?({ 'userIds' => 'alice,bob,carol,dave' }, unleash_context2)).to be_truthy
+      end
+
+      it 'should be enabled with correct can include spaces' do
+        expect(strategy.is_enabled?({ 'userIds' => ' alice ,bob,carol,dave' }, unleash_context)).to be_truthy
+      end
+
+      it 'should be disabled with false params' do
+        expect(strategy.is_enabled?({ 'userIds' => 'alice,dave' }, unleash_context)).to be_falsey
+      end
+
+      it 'should be disabled on invalid params' do
+        expect(strategy.is_enabled?({ 'userIds' => nil }, unleash_context)).to be_falsey
+        expect(strategy.is_enabled?({}, unleash_context)).to be_falsey
+        expect(strategy.is_enabled?('string', unleash_context)).to be_falsey
+        expect(strategy.is_enabled?(nil, unleash_context)).to be_falsey
+      end
+
+      it 'should be disabled on invalid contexts' do
+        expect(strategy.is_enabled?({ 'userIds' => 'alice,bob,carol,dave' }, Unleash::Context.new)).to be_falsey
+        expect(strategy.is_enabled?({ 'userIds' => 'alice,bob,carol,dave' }, nil)).to be_falsey
+        expect(strategy.is_enabled?({ 'userIds' => 'alice,bob,carol,dave' })).to be_falsey
+      end
     end
 
-    it 'should be enabled with correct can include spaces' do
-      expect(strategy.is_enabled?({ 'userIds' => ' alice ,bob,carol,dave' }, unleash_context)).to be_truthy
-    end
+    context 'with int params' do
+      let(:user_id) { 123 }
+      let(:unleash_context) { Unleash::Context.new({ 'userId' => user_id }) }
 
-    it 'should be disabled with false params' do
-      expect(strategy.is_enabled?({ 'userIds' => 'alice,dave' }, unleash_context)).to be_falsey
-    end
+      it 'should be enabled with correct params' do
+        expect(strategy.is_enabled?({ 'userIds' => '1,2,123' }, unleash_context)).to be_truthy
 
-    it 'should be disabled on invalid params' do
-      expect(strategy.is_enabled?({ 'userIds' => nil }, unleash_context)).to be_falsey
-      expect(strategy.is_enabled?({}, unleash_context)).to be_falsey
-      expect(strategy.is_enabled?('string', unleash_context)).to be_falsey
-      expect(strategy.is_enabled?(nil, unleash_context)).to be_falsey
-    end
+        unleash_context2 = Unleash::Context.new(user_id: 1)
+        expect(strategy.is_enabled?({ 'userIds' => '1,2,123' }, unleash_context2)).to be_truthy
+      end
 
-    it 'should be disabled on invalid contexts' do
-      expect(strategy.is_enabled?({ 'userIds' => 'alice,bob,carol,dave' }, Unleash::Context.new)).to be_falsey
-      expect(strategy.is_enabled?({ 'userIds' => 'alice,bob,carol,dave' }, nil)).to be_falsey
-      expect(strategy.is_enabled?({ 'userIds' => 'alice,bob,carol,dave' })).to be_falsey
+      it 'should be enabled with correct can include spaces' do
+        expect(strategy.is_enabled?({ 'userIds' => ' 1 ,2, 123 ,200 ' }, unleash_context)).to be_truthy
+      end
+
+      it 'should be disabled with false params' do
+        expect(strategy.is_enabled?({ 'userIds' => '1,2' }, unleash_context)).to be_falsey
+      end
     end
   end
 end


### PR DESCRIPTION
## About the changes
We should pass user_id as a string in Unleash::Context to make it work. In most cases user_id is an integer, so we have to convert the id into an integer. It's a little annoying to do it all the time.