### PR TITLE
increment metrics in way protected from global state

### DIFF
--- a/lib/unleash/metrics.rb
+++ b/lib/unleash/metrics.rb
@@ -15,15 +15,19 @@ module Unleash
     def increment(feature, choice)
       raise "InvalidArgument choice must be :yes or :no" unless [:yes, :no].include? choice
 
-      self.features[feature] = { yes: 0, no: 0 } unless self.features.include? feature
-      self.features[feature][choice] += 1
+      feature_matrix = self.features[feature] || { yes: 0, no: 0 }
+      feature_matrix[choice] += 1
+
+      self.features[feature] = feature_matrix
     end
 
     def increment_variant(feature, variant)
-      self.features[feature] = { yes: 0, no: 0 } unless self.features.include? feature
-      self.features[feature]['variant'] = {}     unless self.features[feature].include? 'variant'
-      self.features[feature]['variant'][variant] = 0 unless self.features[feature]['variant'].include? variant
-      self.features[feature]['variant'][variant] += 1
+      feature_matrix = self.features[feature] || { yes: 0, no: 0 }
+      feature_matrix['variant'] ||= {}
+      feature_matrix['variant'][variant] ||= 0
+      feature_matrix['variant'][variant] += 1
+
+      self.features[feature] = feature_matrix
     end
 
     def reset


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes
<!-- Describe the changes introduced. What are they and why are they being introduced? Feel free to also add screenshots or steps to view the changes if they're visual. -->

<img width="724" alt="sentry" src="https://user-images.githubusercontent.com/97280/201651355-2a814b82-7d2e-413b-b4f4-82923bbe1f99.png">

In rare cases there can be a race condition when incrementing metrics - `self.features` can be reset between lines 18 and 19 of the screenshot above if metrics are being reported up to the server concurrently, throwing a NoMethodError.

This change uses a local variable to build the new feature metric. It's possible that an increment can be missed during execution of the methods, but this is preferable to throwing an error when using a feature flag in application code.
