### PR TITLE
fix: prevent race condition when manipulating metrics data

### DIFF
--- a/lib/unleash/metrics.rb
+++ b/lib/unleash/metrics.rb
@@ -1,33 +1,40 @@
 module Unleash
   class Metrics
-    attr_accessor :features
-
-    # NOTE: no mutexes for features
+    attr_accessor :features, :features_lock
 
     def initialize
       self.features = {}
+      self.features_lock = Mutex.new
     end
 
     def to_s
-      self.features.to_json
+      self.features_lock.synchronize do
+        return self.features.to_json
+      end
     end
 
     def increment(feature, choice)
       raise "InvalidArgument choice must be :yes or :no" unless [:yes, :no].include? choice
 
-      self.features[feature] = { yes: 0, no: 0 } unless self.features.include? feature
-      self.features[feature][choice] += 1
+      self.features_lock.synchronize do
+        self.features[feature] = { yes: 0, no: 0 } unless self.features.include? feature
+        self.features[feature][choice] += 1
+      end
     end
 
     def increment_variant(feature, variant)
-      self.features[feature] = { yes: 0, no: 0 } unless self.features.include? feature
-      self.features[feature]['variant'] = {}     unless self.features[feature].include? 'variant'
-      self.features[feature]['variant'][variant] = 0 unless self.features[feature]['variant'].include? variant
-      self.features[feature]['variant'][variant] += 1
+      self.features_lock.synchronize do
+        self.features[feature] = { yes: 0, no: 0 } unless self.features.include? feature
+        self.features[feature]['variant'] = {}     unless self.features[feature].include? 'variant'
+        self.features[feature]['variant'][variant] = 0 unless self.features[feature]['variant'].include? variant
+        self.features[feature]['variant'][variant] += 1
+      end
     end
 
     def reset
-      self.features = {}
+      self.features_lock.synchronize do
+        self.features = {}
+      end
     end
   end
 end


### PR DESCRIPTION
The simplest way to guarantee correctness across threads is by synchronising / protecting concurrent data access/change using a mutex, as it is done in the toggle fetcher.

## About the changes
Add locks around data access/changes in the metris reporting data structure. Should have been in place a long time ago. Brought to my attention in PR #121. However the solution proposed there is also not thread-safe. Though it might prevent the exception, it will most definitely not prevent concurrency issues.

Closes #121 


### Important files
`metrics.rb` 🙂 

## Discussion points
This change should have been implemented a long time ago, as was noted in line 5 (`# NOTE: no mutexes for features`). 

This slows down the gathering of metrics, which is in the critical path when evaluating features/variants to about half the speed. Don't think that it matters as much as the correctness gains that this changes provides.

Here is a sample code for evaluating the performance/correctness of this PR (at `./bin/perf_metrics`):

```ruby
#!/usr/bin/env ruby

require './lib/unleash/metrics'
require 'json'

m = Unleash::Metrics.new

threads = []

10.times do
  threads << Thread.new do
    10_000_000.times do
      m.increment 'foo', :yes
    end
  end
end

reader_thread = Thread.new do
  while m.features != {}
    sleep 1
    puts "from reader thread result: #{m}"
    m.reset
    sleep 0.1
  end
end

threads.each(&:join)
reader_thread.join
```

with output:
```
$ git checkout main
$ time ./bin/perf_metrics
(...)
./bin/perf_metrics  35.91s user 0.55s system 97% cpu 37.284 total
$ git checkout  fix/add_mutex_in_metrics
$ time ./bin/perf_metrics 
(...)
./bin/perf_metrics  61.24s user 0.69s system 97% cpu 1:03.48 total
```
 
One could possibly argue for having a test for the concurrency issues that this PR fixes, but I would argue against as those usually tend to be non-deterministic by nature.
