### PR TITLE
Chore: Add support for jruby 9.4

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -28,8 +28,9 @@ jobs:
           - ubuntu
           - macos
         ruby-version:
-          - jruby-9.2
+          - jruby-9.4
           - jruby-9.3
+          - jruby-9.2
           - 3.1
           - '3.0'
           - 2.7

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -38,7 +38,7 @@ jobs:
           - 2.5
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Ruby ${{ matrix.ruby-version }}
         uses: ruby/setup-ruby@v1
         with:

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Leverage the [Unleash Server](https://github.com/Unleash/unleash) for powerful f
   * MRI 2.7
   * MRI 2.6
   * MRI 2.5
+  * jruby 9.4
   * jruby 9.3
   * jruby 9.2
 


### PR DESCRIPTION
## About the changes

Be explicit about jruby 9.4 being supported. See https://www.jruby.org/2022/11/23/jruby-9-4-0-0

Also update a gha step, to avoid warning messages in the build.
