### PR TITLE
Fix/variants dont add to toggle metrics

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -9,7 +9,7 @@ Naming/PredicateName:
 
 
 Metrics/ClassLength:
-  Max: 130
+  Max: 135
 Layout/LineLength:
   Max: 140
 Metrics/MethodLength:

--- a/lib/unleash/metrics.rb
+++ b/lib/unleash/metrics.rb
@@ -22,9 +22,10 @@ module Unleash
       end
     end
 
-    def increment_variant(feature, variant)
+    def increment_variant(feature, choice, variant)
       self.features_lock.synchronize do
         self.features[feature] = { yes: 0, no: 0 } unless self.features.include? feature
+        self.features[feature][choice] += 1
         self.features[feature]['variant'] = {}     unless self.features[feature].include? 'variant'
         self.features[feature]['variant'][variant] = 0 unless self.features[feature]['variant'].include? variant
         self.features[feature]['variant'][variant] += 1

--- a/spec/unleash/client_spec.rb
+++ b/spec/unleash/client_spec.rb
@@ -91,6 +91,7 @@ RSpec.describe Unleash::Client do
 
     # Sending metrics, if they have been evaluated:
     unleash_client.is_enabled?("Feature.A")
+    unleash_client.get_variant("Feature.A")
     Unleash.reporter.post
     expect(
       a_request(:post, "http://test-url/client/metrics")
@@ -98,6 +99,7 @@ RSpec.describe Unleash::Client do
       .with(headers: { 'X-API-KEY': '123', 'Content-Type': 'application/json' })
       .with(headers: { 'UNLEASH-APPNAME': 'my-test-app' })
       .with(headers: { 'UNLEASH-INSTANCEID': 'rspec/test' })
+      .with{ |request| JSON.parse(request.body)['bucket']['toggles']['Feature.A']['yes'] == 2 }
     ).to have_been_made.once
   end
 

--- a/spec/unleash/metrics_spec.rb
+++ b/spec/unleash/metrics_spec.rb
@@ -52,16 +52,21 @@ RSpec.describe Unleash::Metrics do
 
   describe "when dealing with variants" do
     it "counts up correctly" do
-      metrics.increment('featureA', :yes)
+      metrics.increment_variant('featureA', :yes, 'variantA')
+      metrics.increment_variant('featureA', :yes, 'variantA')
+      metrics.increment_variant('featureA', :yes, 'variantB')
 
-      metrics.increment_variant('featureA', 'variantA')
-      metrics.increment_variant('featureA', 'variantA')
-      metrics.increment_variant('featureA', 'variantB')
-
-      expect(metrics.features['featureA'][:yes]).to eq(1)
+      expect(metrics.features['featureA'][:yes]).to eq(3)
       expect(metrics.features['featureA'][:no]).to eq(0)
       expect(metrics.features['featureA']['variant']['variantA']).to eq(2)
       expect(metrics.features['featureA']['variant']['variantB']).to eq(1)
     end
+  end
+
+  it "increments feature toggle counter when variant is resolved" do
+    metrics.increment_variant('featureA', :yes, 'variantA')
+
+    expect(metrics.features['featureA'][:yes]).to eq(1)
+    expect(metrics.features['featureA'][:no]).to eq(0)
   end
 end


### PR DESCRIPTION
This fixes an issue where variants don't report metrics when the toggle is disabled and makes variants increment the parent feature toggle's metrics (this is a spec change that never propagated to this SDK). 