### PR TITLE
fix an issue where constraints would crash with nil context

### DIFF
--- a/lib/unleash/constraint.rb
+++ b/lib/unleash/constraint.rb
@@ -43,6 +43,7 @@ module Unleash
 
     def matches_context?(context)
       Unleash.logger.debug "Unleash::Constraint matches_context? value: #{self.value} context.get_by_name(#{self.context_name})"
+      return false if context.nil?
 
       match = matches_constraint?(context)
       self.inverted ? !match : match

--- a/spec/unleash/constraint_spec.rb
+++ b/spec/unleash/constraint_spec.rb
@@ -451,4 +451,9 @@ RSpec.describe Unleash::Constraint do
       end
     end
   end
+
+  it 'does resolves to false rather than crashing when passed a nil context' do
+    constraint = Unleash::Constraint.new('anything', 'NUM_GTE', '6.282')
+    expect(constraint.matches_context?(nil)).to be false
+  end
 end


### PR DESCRIPTION
This fixes an issue where evaluating a constraint against a nil context would crash. This is an important case because evaluating a feature toggle is technically optional against a context (this works with simple toggles) but practically not optional when complex constraints are added - this forces those constraints to rather disable