### PR TITLE
wraps is_enabled and get_variant in a rescue clause

### DIFF
--- a/lib/unleash/client.rb
+++ b/lib/unleash/client.rb
@@ -48,6 +48,9 @@ module Unleash
       toggle = Unleash::FeatureToggle.new(toggle_as_hash, Unleash&.segment_cache)
 
       toggle.is_enabled?(context)
+    rescue StandardError => e
+      Unleash.logger.warn "An unexpected error occured when evaluating #{feature}: #{e}"
+      false
     end
 
     # enabled? is a more ruby idiomatic method name than is_enabled?
@@ -84,6 +87,9 @@ module Unleash
       # TODO: Add to README: name, payload, enabled (bool)
 
       variant
+    rescue StandardError => e
+      Unleash.logger.warn "An unexpected error occured when resolving variant for #{feature}: #{e}"
+      fallback_variant
     end
 
     # safe shutdown: also flush metrics to server and toggles to disk

--- a/spec/unleash/client_spec.rb
+++ b/spec/unleash/client_spec.rb
@@ -300,6 +300,12 @@ RSpec.describe Unleash::Client do
       unleash_client.is_enabled?('any_feature5', {}) { nil }
     ).to be false
 
+    expect(
+      unleash_client.is_enabled?('any_feature5', {}) do
+        raise StandardError, "Oops, evaluating a feature should not have done this!"
+      end
+    ).to be false
+
     # should never really send both the default value and a default block,
     # but if it is done, we OR the two values
     expect(
@@ -536,6 +542,16 @@ RSpec.describe Unleash::Client do
         ret = client.get_variant(feature)
         expect(ret.enabled).to be false
         expect(ret.name).to eq 'disabled'
+      end
+    end
+
+    context 'when resolve variant errors' do
+      it 'returns disabled variant without crashing' do
+        variant = client.get_variant(feature, {}) do
+          raise StandardError, "Oops, evaluating a feature should not have done this!"
+        end
+        expect(variant.enabled).to be false
+        expect(variant.name).to eq 'disabled'
       end
     end
   end


### PR DESCRIPTION
We've had a number of cases where an exception has not been trapped and handled correctly, resulting in a crash for the system hosting the SDK. Usually these situation are due to using the SDK or server in a strange way but I still strongly feel that the SDK should never result in an exception bubbling up in an  unhandled way.

This might be a more controversial change but this wraps the `is_enabled` and `get_variant` methods in the client in a try/rescue and returns a default but disabled response in both those cases.

This is totally up for debate so comments, thoughts and angry screaming all welcome