### PR TITLE
Update murmurhash3 minimum version to 0.1.7

### DIFF
--- a/unleash-client.gemspec
+++ b/unleash-client.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
   spec.required_ruby_version = ">= 2.5"
 
-  spec.add_dependency "murmurhash3", "~> 0.1.6"
+  spec.add_dependency "murmurhash3", "~> 0.1.7"
 
   spec.add_development_dependency "bundler", "~> 2.1"
   spec.add_development_dependency "rake", "~> 12.3"


### PR DESCRIPTION
This ensures that murmurhash3 will work correctly with native libraries on current Rubygems versions, see
https://github.com/funny-falcon/murmurhash3-ruby/issues/10

<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes
<!-- Describe the changes introduced. What are they and why are they being introduced? Feel free to also add screenshots or steps to view the changes if they're visual. -->
The `murmurhash3` native library is broken on recent versions of Rubygems (3.4+) and causes the following warning:
```
Attention: used pure ruby version of MurmurHash3
``` 
The `murmerhash3` gem has been updated with a fix, and updating this dependency ensures the updated version will be installed.

See:
- https://github.com/funny-falcon/murmurhash3-ruby/issues/10
- https://github.com/rubygems/rubygems/issues/6205

