### PR TITLE
Allow bootstrapped variants when client is disabled

### DIFF
--- a/lib/unleash/client.rb
+++ b/lib/unleash/client.rb
@@ -72,11 +72,6 @@ module Unleash
     def get_variant(feature, context = Unleash::Context.new, fallback_variant = disabled_variant)
       Unleash.logger.debug "Unleash::Client.get_variant for feature: #{feature} with context #{context}"
 
-      if Unleash.configuration.disable_client
-        Unleash.logger.debug "unleash_client is disabled! Always returning #{fallback_variant} for feature #{feature}!"
-        return fallback_variant
-      end
-
       toggle_as_hash = Unleash&.toggles&.select{ |toggle| toggle['name'] == feature }&.first
 
       if toggle_as_hash.nil?

--- a/lib/unleash/feature_toggle.rb
+++ b/lib/unleash/feature_toggle.rb
@@ -97,7 +97,7 @@ module Unleash
     end
 
     def variant_salt(context, stickiness = "default")
-      return context.get_by_name(stickiness) unless stickiness == "default"
+      return context.get_by_name(stickiness) unless stickiness == "default" || context.nil?
       return context.user_id unless context&.user_id.to_s.empty?
       return context.session_id unless context&.session_id.to_s.empty?
       return context.remote_address unless context&.remote_address.to_s.empty?

--- a/lib/unleash/feature_toggle.rb
+++ b/lib/unleash/feature_toggle.rb
@@ -97,7 +97,12 @@ module Unleash
     end
 
     def variant_salt(context, stickiness = "default")
-      return context.get_by_name(stickiness) if !context.nil? && stickiness != "default"
+      begin
+        return context.get_by_name(stickiness) if !context.nil? && stickiness != "default"
+      rescue KeyError
+        Unleash.logger.warn "Custom stickiness key (#{stickiness}) not found in the provided context #{context}. " \
+          "Falling back to default behavior."
+      end
       return context.user_id unless context&.user_id.to_s.empty?
       return context.session_id unless context&.session_id.to_s.empty?
       return context.remote_address unless context&.remote_address.to_s.empty?

--- a/lib/unleash/feature_toggle.rb
+++ b/lib/unleash/feature_toggle.rb
@@ -97,7 +97,7 @@ module Unleash
     end
 
     def variant_salt(context, stickiness = "default")
-      return context.get_by_name(stickiness) if !context.nil? && stickiness != "default" 
+      return context.get_by_name(stickiness) if !context.nil? && stickiness != "default"
       return context.user_id unless context&.user_id.to_s.empty?
       return context.session_id unless context&.session_id.to_s.empty?
       return context.remote_address unless context&.remote_address.to_s.empty?

--- a/lib/unleash/feature_toggle.rb
+++ b/lib/unleash/feature_toggle.rb
@@ -97,7 +97,7 @@ module Unleash
     end
 
     def variant_salt(context, stickiness = "default")
-      return context.get_by_name(stickiness) unless stickiness == "default" || context.nil?
+      return context.get_by_name(stickiness) if !context.nil? && stickiness != "default" 
       return context.user_id unless context&.user_id.to_s.empty?
       return context.session_id unless context&.session_id.to_s.empty?
       return context.remote_address unless context&.remote_address.to_s.empty?

--- a/lib/unleash/feature_toggle.rb
+++ b/lib/unleash/feature_toggle.rb
@@ -98,9 +98,9 @@ module Unleash
 
     def variant_salt(context, stickiness = "default")
       return context.get_by_name(stickiness) unless stickiness == "default"
-      return context.user_id unless context.user_id.to_s.empty?
-      return context.session_id unless context.session_id.to_s.empty?
-      return context.remote_address unless context.remote_address.to_s.empty?
+      return context.user_id unless context&.user_id.to_s.empty?
+      return context.session_id unless context&.session_id.to_s.empty?
+      return context.remote_address unless context&.remote_address.to_s.empty?
 
       SecureRandom.random_number
     end

--- a/spec/unleash/client_spec.rb
+++ b/spec/unleash/client_spec.rb
@@ -187,6 +187,22 @@ RSpec.describe Unleash::Client do
           "name": "featureX",
           "enabled": true,
           "strategies": [{ "name": "default" }]
+        },
+        {
+          "enabled": true,
+          "name": "featureVariantX",
+          "strategies": [{ "name": "default" }],
+          "variants": [
+            {
+              "name": "default-value",
+              "payload": {
+                "type": "string",
+                "value": "info"
+              },
+              "weight": 100,
+              "weightType": "variable"
+            }
+          ]
         }
       ]
     }'
@@ -208,6 +224,15 @@ RSpec.describe Unleash::Client do
     expect(
       unleash_client.is_enabled?('featureX', {}, false)
     ).to be true
+
+    default_variant = Unleash::Variant.new(
+      name: 'featureVariantX',
+      enabled: false,
+      payload: { type: 'string', value: 'bogus' }
+    )
+    variant = unleash_client.get_variant('featureVariantX', nil, default_variant)
+    expect(variant.enabled).to be true
+    expect(variant.payload.fetch('value')).to eq('info')
 
     expect(WebMock).not_to have_requested(:get, 'http://test-url/')
     expect(WebMock).not_to have_requested(:post, 'http://test-url/client/register')

--- a/spec/unleash/client_spec.rb
+++ b/spec/unleash/client_spec.rb
@@ -199,6 +199,7 @@ RSpec.describe Unleash::Client do
                 "type": "string",
                 "value": "info"
               },
+              "stickiness": "custom_attribute",
               "weight": 100,
               "weightType": "variable"
             }


### PR DESCRIPTION
## About the changes

Attempts to address #137

Variants in a bootstrap configuration are ignored with the client is disabled. These changes remove that limitation, so disabled clients can interact with bootstrapped variants.

**Auxiliary changes:**
Calling `get_variant` allows passing a nil context, however attributes of this context are referenced when calculating the variant salt resulting in `undefined method ... for nil` errors. Account for a nil context in this method which results in the default: random number.
