### PR TITLE
fix: forcefully disabling metrics when client is disabled (#139)

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,8 +90,8 @@ Argument | Description | Required? |  Type |  Default Value|
 `project_name` | Name of the project to retrieve features from. If not set, all feature flags will be retrieved. | N | String | nil |
 `refresh_interval` | How often the unleash client should check with the server for configuration changes. | N | Integer |  15 |
 `metrics_interval` | How often the unleash client should send metrics to server. | N | Integer | 60 |
-`disable_client` | Disables all communication with the Unleash server, effectively taking it *offline*. If set, `is_enabled?` will always answer with the `default_value` and configuration validation is skipped. Defeats the entire purpose of using unleash, but can be useful in when running tests. | N | Boolean | `false` |
-`disable_metrics` | Disables sending metrics to Unleash server. | N | Boolean | `false` |
+`disable_client` | Disables all communication with the Unleash server, effectively taking it *offline*. If set, `is_enabled?` will always answer with the `default_value` and configuration validation is skipped. Will also forcefully set `disable_metrics` to `true`. Defeats the entire purpose of using unleash, except when running tests. | N | Boolean | `false` |
+`disable_metrics` | Disables sending metrics to Unleash server. Note that if `disabled_client` is set to `true`, it be overridden to `true`. | N | Boolean | `false` |
 `custom_http_headers` | Custom headers to send to Unleash. As of Unleash v4.0.0, the `Authorization` header is required. For example: `{'Authorization': '<API token>'}` | N | Hash/Proc | {} |
 `timeout` | How long to wait for the connection to be established or wait in reading state (open_timeout/read_timeout) | N | Integer | 30 |
 `retry_limit` | How many consecutive failures in connecting to the Unleash server are allowed before giving up. The default is to retry indefinitely. | N | Float::INFINITY | 5 |

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Argument | Description | Required? |  Type |  Default Value|
 `refresh_interval` | How often the unleash client should check with the server for configuration changes. | N | Integer |  15 |
 `metrics_interval` | How often the unleash client should send metrics to server. | N | Integer | 60 |
 `disable_client` | Disables all communication with the Unleash server, effectively taking it *offline*. If set, `is_enabled?` will always answer with the `default_value` and configuration validation is skipped. Will also forcefully set `disable_metrics` to `true`. Defeats the entire purpose of using unleash, except when running tests. | N | Boolean | `false` |
-`disable_metrics` | Disables sending metrics to Unleash server. Note that if `disabled_client` is set to `true`, it be overridden to `true`. | N | Boolean | `false` |
+`disable_metrics` | Disables sending metrics to Unleash server. If the `disable_client` option is set to `true`, then this option will also be set to `true`, regardless of the value provided. | N | Boolean | `false` |
 `custom_http_headers` | Custom headers to send to Unleash. As of Unleash v4.0.0, the `Authorization` header is required. For example: `{'Authorization': '<API token>'}` | N | Hash/Proc | {} |
 `timeout` | How long to wait for the connection to be established or wait in reading state (open_timeout/read_timeout) | N | Integer | 30 |
 `retry_limit` | How many consecutive failures in connecting to the Unleash server are allowed before giving up. The default is to retry indefinitely. | N | Float::INFINITY | 5 |

--- a/lib/unleash/client.rb
+++ b/lib/unleash/client.rb
@@ -21,7 +21,7 @@ module Unleash
       Unleash.toggle_fetcher = Unleash::ToggleFetcher.new
       if Unleash.configuration.disable_client
         Unleash.logger.warn "Unleash::Client is disabled! Will only return default (or bootstrapped if available) results!"
-        Unleash.logger.warn "Unleash::Client is disabled! Metrics and MetricsReporter also are disabled!"
+        Unleash.logger.warn "Unleash::Client is disabled! Metrics and MetricsReporter are also disabled!"
         Unleash.configuration.disable_metrics = true
         return
       end

--- a/lib/unleash/client.rb
+++ b/lib/unleash/client.rb
@@ -21,6 +21,8 @@ module Unleash
       Unleash.toggle_fetcher = Unleash::ToggleFetcher.new
       if Unleash.configuration.disable_client
         Unleash.logger.warn "Unleash::Client is disabled! Will only return default (or bootstrapped if available) results!"
+        Unleash.logger.warn "Unleash::Client is disabled! Metrics and MetricsReporter also are disabled!"
+        Unleash.configuration.disable_metrics = true
         return
       end
 


### PR DESCRIPTION

## About the changes
Disabling the client is meant for when a user will be testing their code, and no connection to a remote server is desired.

It is hard to see a use case for collecting and reporting metrics if the client is disabled. Forcefully disabling metrics when disabling the client makes sense and is a more coherent behavior.

Closes #139

Note that this change does change behavior, but to make things more sane.

### Important files
* `client.rb`
* `client_spec.rb`

## Discussion points
Also added `WebMock.reset!` in the `client_spec.rb` to ensure no leakage between tests.

Maybe it would have made more sense to have it overridden in `lib/unleash/configuration.rb` (by moving `disable_metrics` from `attr_accessor` to `attr_writter` + own getter) ?
