### PR TITLE
chore: update gems: rspec, webmock and rubocop

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -38,6 +38,8 @@ jobs:
           - 2.6
           - 2.5
 
+    needs:
+      - lint
     steps:
       - uses: actions/checkout@v3
       - name: Set up Ruby ${{ matrix.ruby-version }}

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -10,11 +10,11 @@ jobs:
     timeout-minutes: 30
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: "2.7"
+        ruby-version: "3.0"
         bundler-cache: true
     - name: Run RuboCop
       run: bundle exec rubocop

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -11,6 +11,8 @@ Naming/PredicateName:
 
 Metrics/ClassLength:
   Max: 135
+  CountAsOne:
+    - 'method_call'
 Layout/LineLength:
   Max: 140
 Metrics/MethodLength:

--- a/spec/unleash/constraint_spec.rb
+++ b/spec/unleash/constraint_spec.rb
@@ -50,8 +50,7 @@ RSpec.describe Unleash::Constraint do
 
     it 'matches based on a value NOT_IN in a not existing context field' do
       context_params = {
-        properties: {
-        }
+        properties: {}
       }
       context = Unleash::Context.new(context_params)
       constraint = Unleash::Constraint.new('env', 'NOT_IN', ['anything'])

--- a/spec/unleash/feature_toggle_spec.rb
+++ b/spec/unleash/feature_toggle_spec.rb
@@ -434,8 +434,7 @@ RSpec.describe Unleash::FeatureToggle do
               }
             ],
             "name" => "default",
-            "parameters" => {
-            }
+            "parameters" => {}
           }
         ]
       )
@@ -480,8 +479,7 @@ RSpec.describe Unleash::FeatureToggle do
               }
             ],
             "name" => "default",
-            "parameters" => {
-            }
+            "parameters" => {}
           }
         ]
       )

--- a/unleash-client.gemspec
+++ b/unleash-client.gemspec
@@ -27,11 +27,16 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "bundler", "~> 2.1"
   spec.add_development_dependency "rake", "~> 12.3"
-  spec.add_development_dependency "rspec", "~> 3.9"
+  spec.add_development_dependency "rspec", "~> 3.12"
   spec.add_development_dependency "rspec-json_expectations", "~> 2.2"
-  spec.add_development_dependency "webmock", "~> 3.8"
+  spec.add_development_dependency "webmock", "~> 3.18.1"
 
-  spec.add_development_dependency "rubocop", "~> 1.28.2"
+  # rubocop:disable Gemspec/RubyVersionGlobalsUsage, Style/IfUnlessModifier
+  if Gem::Version.new(RUBY_VERSION) > Gem::Version.new('3.0')
+    spec.add_development_dependency "rubocop", "~> 1.51.0"
+  end
+  # rubocop:enable Gemspec/RubyVersionGlobalsUsage, Style/IfUnlessModifier
+
   spec.add_development_dependency "simplecov", "~> 0.21.2"
   spec.add_development_dependency "simplecov-lcov", "~> 0.8.0"
 end


### PR DESCRIPTION
## About the changes
Update development gems.

Unfortunately these changes are tightly coupled, so a smaller PR is not really feasible.

## Discussion points
Updated github actions/checkout  to a supported version.

Updated `Metrics/ClassLength` in rubocop config so PR in #138 should not fail.

Note that rubocop now will only work on supported versions of ruby. Given that this is only for when developmening/testing, it should be fair to have the `if RUBY_VERSION` around it, even if in principle that's not ideal. The other option would be to stop supporting ancient versions of ruby, but that's not an adequate trade-off. 

Linted some code so the new rubopcop is happy.