### PR TITLE
Fix handling of invalid context in get_variant

### DIFF
--- a/lib/unleash/context.rb
+++ b/lib/unleash/context.rb
@@ -27,6 +27,7 @@ module Unleash
       ATTRS.map{ |attr| [attr, self.send(attr)] }.to_h.merge(properties: @properties)
     end
 
+    # returns the value found for the key in the context, or raises a KeyError exception if not found.
     def get_by_name(name)
       normalized_name = underscore(name).to_sym
 


### PR DESCRIPTION
## About the changes

Should be merged ONLY after #138, #142 are merged.

Adds test cases that #138 did not cover. #138 should soon have the fix in `feature_toggle.rb` that is included here. (but I  will be remove from this PR when rebasing once #138 is merged). The fix is included here to show that the tests fail w/o it, and pass with it.

Also added a comment in `get_by_name()` in `context.rb` as a reminder that it will throw exceptions when a key is not found (IIRC by design).

PR #142 fixes the rubocop issues found here.

Kudos to @jdurkee-mdsol for finding the bug where we didn't handle the case for get_variant when the context wasn't valid.
