### PR TITLE
fix: fix variant metrics json payload: variant -> variants

### DIFF
--- a/lib/unleash/metrics.rb
+++ b/lib/unleash/metrics.rb
@@ -26,9 +26,9 @@ module Unleash
       self.features_lock.synchronize do
         self.features[feature] = { yes: 0, no: 0 } unless self.features.include? feature
         self.features[feature][choice] += 1
-        self.features[feature]['variant'] = {}     unless self.features[feature].include? 'variant'
-        self.features[feature]['variant'][variant] = 0 unless self.features[feature]['variant'].include? variant
-        self.features[feature]['variant'][variant] += 1
+        self.features[feature]['variants'] = {}     unless self.features[feature].include? 'variants'
+        self.features[feature]['variants'][variant] = 0 unless self.features[feature]['variants'].include? variant
+        self.features[feature]['variants'][variant] += 1
       end
     end
 

--- a/spec/unleash/metrics_spec.rb
+++ b/spec/unleash/metrics_spec.rb
@@ -58,8 +58,8 @@ RSpec.describe Unleash::Metrics do
 
       expect(metrics.features['featureA'][:yes]).to eq(3)
       expect(metrics.features['featureA'][:no]).to eq(0)
-      expect(metrics.features['featureA']['variant']['variantA']).to eq(2)
-      expect(metrics.features['featureA']['variant']['variantB']).to eq(1)
+      expect(metrics.features['featureA']['variants']['variantA']).to eq(2)
+      expect(metrics.features['featureA']['variants']['variantB']).to eq(1)
     end
   end
 


### PR DESCRIPTION
This change fixes an error in the metrics payload sent to the server:
the previous payload stored a feature's variant metrics under the
`variant` property, but the API expects the property to be `variants` (pluralized).