### PR TITLE
fix: flexible rollout strategy without context

### DIFF
--- a/lib/unleash/strategy/flexible_rollout.rb
+++ b/lib/unleash/strategy/flexible_rollout.rb
@@ -43,7 +43,7 @@ module Unleash
           random
         when 'default'
           return random unless context.instance_of?(Unleash::Context)
-          
+
           context.user_id || context.session_id || random
         else
           begin

--- a/lib/unleash/strategy/flexible_rollout.rb
+++ b/lib/unleash/strategy/flexible_rollout.rb
@@ -42,9 +42,7 @@ module Unleash
         when 'random'
           random
         when 'default'
-          return random unless context.instance_of?(Unleash::Context)
-
-          context.user_id || context.session_id || random
+          context&.user_id || context&.session_id || random
         else
           begin
             context.get_by_name(stickiness)

--- a/lib/unleash/strategy/flexible_rollout.rb
+++ b/lib/unleash/strategy/flexible_rollout.rb
@@ -12,7 +12,7 @@ module Unleash
         return false unless params.is_a?(Hash)
 
         stickiness = params.fetch('stickiness', 'default')
-        return false unless context.instance_of?(Unleash::Context) || ['random', 'default'].include?(stickiness)
+        return false unless context_is_sufficient?(stickiness, context)
 
         stickiness_id = resolve_stickiness(stickiness, context)
 
@@ -32,6 +32,12 @@ module Unleash
       end
 
       private
+
+      def context_is_sufficient?(stickiness, context)
+        return true if ['random', 'default'].include?(stickiness)
+
+        context.instance_of?(Unleash::Context)
+      end
 
       def random
         Random.rand(0..100)

--- a/lib/unleash/strategy/flexible_rollout.rb
+++ b/lib/unleash/strategy/flexible_rollout.rb
@@ -13,6 +13,7 @@ module Unleash
 
         stickiness = params.fetch('stickiness', 'default')
         return false unless context.instance_of?(Unleash::Context) || ['random', 'default'].include?(stickiness)
+        
         stickiness_id = resolve_stickiness(stickiness, context)
 
         begin

--- a/lib/unleash/strategy/flexible_rollout.rb
+++ b/lib/unleash/strategy/flexible_rollout.rb
@@ -12,7 +12,7 @@ module Unleash
         return false unless params.is_a?(Hash)
 
         stickiness = params.fetch('stickiness', 'default')
-        return false unless context_is_sufficient?(stickiness, context)
+        return false if context_invalid?(stickiness, context)
 
         stickiness_id = resolve_stickiness(stickiness, context)
 
@@ -33,10 +33,10 @@ module Unleash
 
       private
 
-      def context_is_sufficient?(stickiness, context)
-        return true if ['random', 'default'].include?(stickiness)
+      def context_invalid?(stickiness, context)
+        return false if ['random', 'default'].include?(stickiness)
 
-        context.instance_of?(Unleash::Context)
+        !context.instance_of?(Unleash::Context)
       end
 
       def random

--- a/lib/unleash/strategy/flexible_rollout.rb
+++ b/lib/unleash/strategy/flexible_rollout.rb
@@ -12,7 +12,7 @@ module Unleash
         return false unless params.is_a?(Hash)
 
         stickiness = params.fetch('stickiness', 'default')
-        return false unless ( context.instance_of?(Unleash::Context) || ['random', 'default'].include?(stickiness) )
+        return false unless context.instance_of?(Unleash::Context) || ['random', 'default'].include?(stickiness)
         stickiness_id = resolve_stickiness(stickiness, context)
 
         begin

--- a/lib/unleash/strategy/flexible_rollout.rb
+++ b/lib/unleash/strategy/flexible_rollout.rb
@@ -10,9 +10,9 @@ module Unleash
       # need: params['percentage']
       def is_enabled?(params = {}, context = nil)
         return false unless params.is_a?(Hash)
-        return false unless context.instance_of?(Unleash::Context)
 
         stickiness = params.fetch('stickiness', 'default')
+        return false unless ( context.instance_of?(Unleash::Context) || ['random', 'default'].include?(stickiness) )
         stickiness_id = resolve_stickiness(stickiness, context)
 
         begin
@@ -41,6 +41,7 @@ module Unleash
         when 'random'
           random
         when 'default'
+          return random unless context.instance_of?(Unleash::Context)
           context.user_id || context.session_id || random
         else
           begin

--- a/lib/unleash/strategy/flexible_rollout.rb
+++ b/lib/unleash/strategy/flexible_rollout.rb
@@ -48,6 +48,8 @@ module Unleash
         when 'random'
           random
         when 'default'
+          return random unless context.instance_of?(Unleash::Context)
+
           context&.user_id || context&.session_id || random
         else
           begin

--- a/lib/unleash/strategy/flexible_rollout.rb
+++ b/lib/unleash/strategy/flexible_rollout.rb
@@ -13,7 +13,7 @@ module Unleash
 
         stickiness = params.fetch('stickiness', 'default')
         return false unless context.instance_of?(Unleash::Context) || ['random', 'default'].include?(stickiness)
-        
+
         stickiness_id = resolve_stickiness(stickiness, context)
 
         begin
@@ -43,6 +43,7 @@ module Unleash
           random
         when 'default'
           return random unless context.instance_of?(Unleash::Context)
+          
           context.user_id || context.session_id || random
         else
           begin

--- a/spec/unleash/strategy/flexible_rollout_spec.rb
+++ b/spec/unleash/strategy/flexible_rollout_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Unleash::Strategy::FlexibleRollout do
     let(:strategy) { Unleash::Strategy::FlexibleRollout.new }
     let(:unleash_context) { Unleash::Context.new }
 
-    it 'should always be enabled when rollout is set to 100, disabled when set to 0' do
+    it 'should always be enabled when stickiness is default and rollout is set to 100' do
       params = {
         'groupId' => 'Demo',
         'rollout' => 100,
@@ -14,8 +14,39 @@ RSpec.describe Unleash::Strategy::FlexibleRollout do
 
       expect(strategy.is_enabled?(params, unleash_context)).to be_truthy
       expect(strategy.is_enabled?(params, nil)).to be_truthy
-      expect(strategy.is_enabled?(params.merge({ 'rollout' => 0 }), unleash_context)).to be_falsey
-      expect(strategy.is_enabled?(params.merge({ 'rollout' => 0 }), nil)).to be_falsey
+    end
+
+    it 'should always be disabled when stickiness is default and rollout is set to 0' do
+      params = {
+        'groupId' => 'Demo',
+        'rollout' => 0,
+        'stickiness' => 'default'
+      }
+
+      expect(strategy.is_enabled?(params, unleash_context)).to be_falsey
+      expect(strategy.is_enabled?(params, nil)).to be_falsey
+    end
+
+    it 'should always be enabled when stickiness is random and rollout is set to 100' do
+      params = {
+        'groupId' => 'Demo',
+        'rollout' => 100,
+        'stickiness' => 'random'
+      }
+
+      expect(strategy.is_enabled?(params, unleash_context)).to be_truthy
+      expect(strategy.is_enabled?(params, nil)).to be_truthy
+    end
+
+    it 'should always be disabled when stickiness is random and rollout is set to 0' do
+      params = {
+        'groupId' => 'Demo',
+        'rollout' => 0,
+        'stickiness' => 'random'
+      }
+
+      expect(strategy.is_enabled?(params, unleash_context)).to be_falsey
+      expect(strategy.is_enabled?(params, nil)).to be_falsey
     end
 
     it 'should behave predictably when based on the normalized_number' do
@@ -45,6 +76,7 @@ RSpec.describe Unleash::Strategy::FlexibleRollout do
       )
 
       expect(strategy.is_enabled?(params, custom_context)).to be_truthy
+      expect(strategy.is_enabled?(params, nil)).to be_falsey
     end
 
     it 'should be disabled when stickiness=customerId and customerId=63 and rollout=10' do
@@ -61,6 +93,7 @@ RSpec.describe Unleash::Strategy::FlexibleRollout do
       )
 
       expect(strategy.is_enabled?(params, custom_context)).to be_falsey
+      expect(strategy.is_enabled?(params, nil)).to be_falsey
     end
   end
 end

--- a/spec/unleash/strategy/flexible_rollout_spec.rb
+++ b/spec/unleash/strategy/flexible_rollout_spec.rb
@@ -16,7 +16,6 @@ RSpec.describe Unleash::Strategy::FlexibleRollout do
       expect(strategy.is_enabled?(params, nil)).to be_truthy
       expect(strategy.is_enabled?(params.merge({ 'rollout' => 0 }), unleash_context)).to be_falsey
       expect(strategy.is_enabled?(params.merge({ 'rollout' => 0 }), nil)).to be_falsey
-
     end
 
     it 'should behave predictably when based on the normalized_number' do

--- a/spec/unleash/strategy/flexible_rollout_spec.rb
+++ b/spec/unleash/strategy/flexible_rollout_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe Unleash::Strategy::FlexibleRollout do
       }
 
       expect(strategy.is_enabled?(params, unleash_context)).to be_truthy
+      expect(strategy.is_enabled?(params, "invalid context")).to be_truthy
       expect(strategy.is_enabled?(params, nil)).to be_truthy
     end
 
@@ -24,6 +25,7 @@ RSpec.describe Unleash::Strategy::FlexibleRollout do
       }
 
       expect(strategy.is_enabled?(params, unleash_context)).to be_falsey
+      expect(strategy.is_enabled?(params, "invalid context")).to be_falsey
       expect(strategy.is_enabled?(params, nil)).to be_falsey
     end
 
@@ -35,6 +37,7 @@ RSpec.describe Unleash::Strategy::FlexibleRollout do
       }
 
       expect(strategy.is_enabled?(params, unleash_context)).to be_truthy
+      expect(strategy.is_enabled?(params, "invalid context")).to be_truthy
       expect(strategy.is_enabled?(params, nil)).to be_truthy
     end
 
@@ -46,6 +49,7 @@ RSpec.describe Unleash::Strategy::FlexibleRollout do
       }
 
       expect(strategy.is_enabled?(params, unleash_context)).to be_falsey
+      expect(strategy.is_enabled?(params, "invalid context")).to be_falsey
       expect(strategy.is_enabled?(params, nil)).to be_falsey
     end
 

--- a/spec/unleash/strategy/flexible_rollout_spec.rb
+++ b/spec/unleash/strategy/flexible_rollout_spec.rb
@@ -13,7 +13,10 @@ RSpec.describe Unleash::Strategy::FlexibleRollout do
       }
 
       expect(strategy.is_enabled?(params, unleash_context)).to be_truthy
+      expect(strategy.is_enabled?(params, nil)).to be_truthy
       expect(strategy.is_enabled?(params.merge({ 'rollout' => 0 }), unleash_context)).to be_falsey
+      expect(strategy.is_enabled?(params.merge({ 'rollout' => 0 }), nil)).to be_falsey
+
     end
 
     it 'should behave predictably when based on the normalized_number' do


### PR DESCRIPTION
The flexible rollout strategy should evaluate default and random stickiness even if context is not provided.
