### PR TITLE
chore: update client-specifications to 4.3.3

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Install dependencies
         run: bundle install
       - name: Download test cases
-        run: git clone --depth 5 --branch v4.3.1 https://github.com/Unleash/client-specification.git client-specification
+        run: git clone --depth 5 --branch v4.3.3 https://github.com/Unleash/client-specification.git client-specification
       - name: Run tests
         run: bundle exec rake
         env:

--- a/README.md
+++ b/README.md
@@ -528,7 +528,7 @@ You can also run `bin/console` for an interactive prompt that will allow you to 
 This SDK is also built against the Unleash Client Specification tests.
 To run the Ruby SDK against this test suite, you'll need to have a copy on your machine, you can clone the repository directly using:
 
-`git clone --depth 5 --branch v4.3.1 https://github.com/Unleash/client-specification.git client-specification`
+`git clone --depth 5 --branch v4.3.3 https://github.com/Unleash/client-specification.git client-specification`
 
 After doing this, `rake spec` will also run the client specification tests.
 


### PR DESCRIPTION
We added some specifications for some edge cases. The ruby sdk supports this, but nice to have updated the client specifications
