### PR TITLE
docs: lowercase link to installation section of readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -539,7 +539,7 @@ To install this gem onto your local machine, run `bundle exec rake install`.
 Choose a new version number following [Semantic Versioning](https://semver.org/spec/v2.0.0.html) semantics and then:
 
 - update the version number in [./lib/unleash/version.rb](./lib/unleash/version.rb),
-- if a major or minor version bump, update the [Installation section](#Installation) in [README.md](README.md)
+- if a major or minor version bump, update the [Installation section](#installation) in [README.md](README.md)
 - update [CHANGELOG.md](CHANGELOG.md) following the format on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 - commit with message `chore: bump version to x.y.z`
 - then run `bundle exec rake release`


### PR DESCRIPTION
Markdown generators (including GitHub) tend to lowercase the titles
when they create anchor links. Most browsers might be able to handle
mixed case, but some of our tools don't.

Update: this was not breaking the docs build for Unleash. I was wrong. The docs build issue was a separate issue entirely.

However, this does seem to cause issues with the link on the rendered doc, as the browser can't find it correctly, so lowercasing it isn't a bad thing. That said, that should be handled by the doc generator going forward, and there is a [PR to do just that](https://github.com/Unleash/unleash/pull/4963).