### PR TITLE
fix: change seed for variantutils to ensure fair distribution

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Install dependencies
         run: bundle install
       - name: Download test cases
-        run: git clone --depth 5 --branch v4.5.1 https://github.com/Unleash/client-specification.git client-specification
+        run: git clone --depth 5 --branch v5.0.2 https://github.com/Unleash/client-specification.git client-specification
       - name: Run tests
         run: bundle exec rake
         env:

--- a/README.md
+++ b/README.md
@@ -528,7 +528,7 @@ You can also run `bin/console` for an interactive prompt that will allow you to 
 This SDK is also built against the Unleash Client Specification tests.
 To run the Ruby SDK against this test suite, you'll need to have a copy on your machine, you can clone the repository directly using:
 
-`git clone --depth 5 --branch v4.5.1 https://github.com/Unleash/client-specification.git client-specification`
+`git clone --depth 5 --branch v5.0.2 https://github.com/Unleash/client-specification.git client-specification`
 
 After doing this, `rake spec` will also run the client specification tests.
 

--- a/lib/unleash/configuration.rb
+++ b/lib/unleash/configuration.rb
@@ -53,7 +53,7 @@ module Unleash
       {
         'UNLEASH-INSTANCEID' => self.instance_id,
         'UNLEASH-APPNAME' => self.app_name,
-        'Unleash-Client-Spec' => '4.5.1'
+        'Unleash-Client-Spec' => '5.0.2'
       }.merge!(generate_custom_http_headers)
     end
 

--- a/lib/unleash/feature_toggle.rb
+++ b/lib/unleash/feature_toggle.rb
@@ -163,6 +163,7 @@ module Unleash
       variant_weight = Unleash::Strategy::Util.get_normalized_number(
         variant_salt(context, stickiness),
         group_id,
+        Unleash::Strategy::Util::VARIANT_NORMALIZER_SEED,
         sum_variant_defs_weights(variant_definitions)
       )
       prev_weights = 0

--- a/lib/unleash/strategy/flexible_rollout.rb
+++ b/lib/unleash/strategy/flexible_rollout.rb
@@ -24,7 +24,7 @@ module Unleash
         end
 
         group_id = params.fetch('groupId', '')
-        normalized_number = Util.get_normalized_number(stickiness_id, group_id)
+        normalized_number = Util.get_normalized_number(stickiness_id, group_id, 0)
 
         return false if stickiness_id.nil?
 

--- a/lib/unleash/strategy/gradual_rollout_sessionid.rb
+++ b/lib/unleash/strategy/gradual_rollout_sessionid.rb
@@ -14,7 +14,7 @@ module Unleash
         return false if context.session_id.nil? || context.session_id.empty?
 
         percentage = Integer(params['percentage'] || 0)
-        (percentage.positive? && Util.get_normalized_number(context.session_id, params['groupId'] || "") <= percentage)
+        (percentage.positive? && Util.get_normalized_number(context.session_id, params['groupId'] || "", 0) <= percentage)
       end
     end
   end

--- a/lib/unleash/strategy/gradual_rollout_userid.rb
+++ b/lib/unleash/strategy/gradual_rollout_userid.rb
@@ -14,7 +14,7 @@ module Unleash
         return false if context.user_id.nil? || context.user_id.empty?
 
         percentage = Integer(params['percentage'] || 0)
-        (percentage.positive? && Util.get_normalized_number(context.user_id, params['groupId'] || "") <= percentage)
+        (percentage.positive? && Util.get_normalized_number(context.user_id, params['groupId'] || "", 0) <= percentage)
       end
     end
   end

--- a/lib/unleash/strategy/util.rb
+++ b/lib/unleash/strategy/util.rb
@@ -6,10 +6,11 @@ module Unleash
       module_function
 
       NORMALIZER = 100
+      VARIANT_NORMALIZER_SEED = 86028157;
 
       # convert the two strings () into a number between 1 and base (100 by default)
-      def get_normalized_number(identifier, group_id, base = NORMALIZER)
-        MurmurHash3::V32.str_hash("#{group_id}:#{identifier}") % base + 1
+      def get_normalized_number(identifier, group_id, seed, base = NORMALIZER)
+        MurmurHash3::V32.str_hash("#{group_id}:#{identifier}", seed) % base + 1
       end
     end
   end

--- a/spec/unleash/configuration_spec.rb
+++ b/spec/unleash/configuration_spec.rb
@@ -146,7 +146,7 @@ RSpec.describe Unleash do
           'X-API-KEY' => '123',
           'UNLEASH-APPNAME' => 'test-app',
           'UNLEASH-INSTANCEID' => config.instance_id,
-          'Unleash-Client-Spec' => '4.5.1'
+          'Unleash-Client-Spec' => '5.0.2'
         }
       )
       expect(custom_headers_proc).to have_received(:call).exactly(1).times

--- a/spec/unleash/feature_toggle_spec.rb
+++ b/spec/unleash/feature_toggle_spec.rb
@@ -141,19 +141,19 @@ RSpec.describe Unleash::FeatureToggle do
 
     let(:default_variant) { Unleash::Variant.new(name: 'unknown', default: true) }
 
-    it 'should return variant1 for user_id:1' do
+    it 'should return variant2 for user_id:1' do
       context = Unleash::Context.new(user_id: 10)
       expect(feature_toggle.get_variant(context, default_variant)).to have_attributes(
-        name: "variant1",
+        name: "variant2",
         enabled: true,
         payload: nil
       )
     end
 
-    it 'should return variant2 for user_id:2' do
+    it 'should return variant1 for user_id:2' do
       context = Unleash::Context.new(user_id: 2)
       expect(feature_toggle.get_variant(context, default_variant)).to have_attributes(
-        name: "variant2",
+        name: "variant1",
         enabled: true,
         payload: nil
       )
@@ -208,8 +208,8 @@ RSpec.describe Unleash::FeatureToggle do
       )
     end
 
-    it 'should return variantB for user_id:2' do
-      context = Unleash::Context.new(user_id: 2)
+    it 'should return variantB for user_id:5' do
+      context = Unleash::Context.new(user_id: 5)
       expect(feature_toggle.get_variant(context, default_variant)).to have_attributes(
         name: "variantB",
         enabled: true,
@@ -285,7 +285,7 @@ RSpec.describe Unleash::FeatureToggle do
             },
             "overrides" => [{
               "contextName" => "userId",
-              "values" => ["132", "61"]
+              "values" => ["133", "61"]
             }]
           },
           {
@@ -311,8 +311,8 @@ RSpec.describe Unleash::FeatureToggle do
       )
     end
 
-    it 'should return variant1 for user_id:132 from override' do
-      context = Unleash::Context.new("userId" => 132)
+    it 'should return variant1 for user_id:133 from override' do
+      context = Unleash::Context.new("userId" => 133)
       expect(feature_toggle.get_variant(context)).to have_attributes(
         name: "variant1",
         enabled: true,
@@ -320,8 +320,8 @@ RSpec.describe Unleash::FeatureToggle do
       )
     end
 
-    it 'should return variant2 for user_id:60' do
-      context = Unleash::Context.new(user_id: 60)
+    it 'should return variant2 for user_id:856' do
+      context = Unleash::Context.new(user_id: 856)
       expect(feature_toggle.get_variant(context)).to have_attributes(
         name: "variant2",
         enabled: true,
@@ -537,10 +537,10 @@ RSpec.describe Unleash::FeatureToggle do
       )
     end
 
-    it 'should return variant1 organization 726' do
+    it 'should return variant1 organization 222' do
       context = Unleash::Context.new(
         properties: {
-          organization: '726'
+          organization: '222'
         }
       )
 
@@ -553,7 +553,7 @@ RSpec.describe Unleash::FeatureToggle do
     it 'should return variant2 organization 48' do
       context = Unleash::Context.new(
         properties: {
-          organization: '48'
+          organization: '49'
         }
       )
 
@@ -563,10 +563,10 @@ RSpec.describe Unleash::FeatureToggle do
       )
     end
 
-    it 'should return variant3 organization 381' do
+    it 'should return variant3 organization 726' do
       context = Unleash::Context.new(
         properties: {
-          organization: '381'
+          organization: '726'
         }
       )
 
@@ -576,10 +576,10 @@ RSpec.describe Unleash::FeatureToggle do
       )
     end
 
-    it 'should return variant4 organization 222' do
+    it 'should return variant4 organization 381' do
       context = Unleash::Context.new(
         properties: {
-          organization: '222'
+          organization: '381'
         }
       )
 

--- a/spec/unleash/strategy/gradual_rollout_sessionid_spec.rb
+++ b/spec/unleash/strategy/gradual_rollout_sessionid_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Unleash::Strategy::GradualRolloutSessionId do
   describe '#is_enabled?' do
     let(:strategy) { Unleash::Strategy::GradualRolloutSessionId.new }
     let(:unleash_context) { Unleash::Context.new(session_id: 'secretsessionidhashgoeshere') }
-    let(:percentage) { Unleash::Strategy::Util.get_normalized_number(unleash_context.session_id, "") }
+    let(:percentage) { Unleash::Strategy::Util.get_normalized_number(unleash_context.session_id, "", 0) }
 
     it 'return true when percentage set is gt the number returned by the hash function' do
       expect(strategy.is_enabled?({ 'percentage' => (percentage + 1).to_s }, unleash_context)).to be_truthy

--- a/spec/unleash/strategy/gradual_rollout_userid_spec.rb
+++ b/spec/unleash/strategy/gradual_rollout_userid_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Unleash::Strategy::GradualRolloutUserId do
   describe '#is_enabled?' do
     let(:strategy) { Unleash::Strategy::GradualRolloutUserId.new }
     let(:unleash_context) { Unleash::Context.new({ 'userId' => 'alice' }) }
-    let(:percentage) { Unleash::Strategy::Util.get_normalized_number(unleash_context.user_id, "") }
+    let(:percentage) { Unleash::Strategy::Util.get_normalized_number(unleash_context.user_id, "", 0) }
 
     it 'return true when percentage set is gt the number returned by the hash function' do
       expect(strategy.is_enabled?({ 'percentage' => (percentage + 1).to_s }, unleash_context)).to be_truthy

--- a/spec/unleash/strategy/util_spec.rb
+++ b/spec/unleash/strategy/util_spec.rb
@@ -3,8 +3,8 @@ require "unleash/strategy/util"
 RSpec.describe Unleash::Strategy::Util do
   describe '.get_normalized_number' do
     it "returns correct values" do
-      expect(Unleash::Strategy::Util.get_normalized_number('123', 'gr1')).to eq(73)
-      expect(Unleash::Strategy::Util.get_normalized_number('999', 'groupX')).to eq(25)
+      expect(Unleash::Strategy::Util.get_normalized_number('123', 'gr1', 0)).to eq(73)
+      expect(Unleash::Strategy::Util.get_normalized_number('999', 'groupX', 0)).to eq(25)
     end
   end
 end


### PR DESCRIPTION
# What
Uses a new seed for ensuring a fair distribution for variants.

# Background
After a customer reported that variant distribution seemed skewed we performed some testing and found that since we use the same hash string for both gradual rollout and variant allocation we'd reduced the set of groups we could get to whatever percentage our gradual rollout was set.

# Example
Take a gradualRollout of 10%, this will select normalized hashes between 1 and 10, when we then again hash the same string that gave us between 1 and 10, but with modulo 1000 for variants, this will only give us 100 possible groups, instead of the expected 1000.

# Fix
Force the normalization to accept a seed, and make sure to use a new seed when normalizing the variant distribution hash.

# Worth noting
This will require release 5.0.0, since we are changing how hashing works.
