### PR TITLE
fix: make client resilient to non-conforming responses from `unleash-edge`

### DIFF
--- a/lib/unleash/feature_toggle.rb
+++ b/lib/unleash/feature_toggle.rb
@@ -189,7 +189,7 @@ module Unleash
     end
 
     def initialize_strategies(params, segment_map)
-      params.fetch('strategies', [])
+      (params.fetch('strategies', []) || [])
         .select{ |s| s.has_key?('name') && Unleash.strategies.includes?(s['name']) }
         .map do |s|
           ActivationStrategy.new(
@@ -202,7 +202,7 @@ module Unleash
     end
 
     def resolve_variants(strategy)
-      strategy.fetch("variants", [])
+      (strategy.fetch("variants", []) || [])
         .select{ |variant| variant.is_a?(Hash) && variant.has_key?("name") }
         .map do |variant|
           VariantDefinition.new(


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes
<!-- Describe the changes introduced. What are they and why are they being introduced? Feel free to also add screenshots or steps to view the changes if they're visual. -->


<!-- Does it close an issue? Multiple? -->

Works around https://github.com/Unleash/unleash-edge/issues/353

```
irb(main):005:0> UNLEASH.is_enabled?("some-existent-toggle")
Traceback (most recent call last):
        1: from (irb):5
NoMethodError (private method `select' called for nil:NilClass)

Stacktrace: /usr/local/lib/ruby/gems/2.7.0/gems/unleash-5.0.0/lib/unleash/feature_toggle.rb:206:in `resolve_variants'
/usr/local/lib/ruby/gems/2.7.0/gems/unleash-5.0.0/lib/unleash/feature_toggle.rb:199:in `block in initialize_strategies'
/usr/local/lib/ruby/gems/2.7.0/gems/unleash-5.0.0/lib/unleash/feature_toggle.rb:194:in `map'
/usr/local/lib/ruby/gems/2.7.0/gems/unleash-5.0.0/lib/unleash/feature_toggle.rb:194:in `initialize_strategies'
/usr/local/lib/ruby/gems/2.7.0/gems/unleash-5.0.0/lib/unleash/feature_toggle.rb:21:in `initialize'
/usr/local/lib/ruby/gems/2.7.0/gems/unleash-5.0.0/lib/unleash/client.rb:49:in `new'
/usr/local/lib/ruby/gems/2.7.0/gems/unleash-5.0.0/lib/unleash/client.rb:49:in `is_enabled?'
```

<!-- (For internal contributors): Does it relate to an issue on public roadmap? -->
<!--
Relates to [roadmap](https://github.com/orgs/Unleash/projects/10) item: #
-->

### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->

Only one file changed


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->

Arguably this is working around a bug in `unleash-edge`, but the same `.fetch('thing', default) || []` fallback is used throughout the code base.