### PR TITLE
feat: make user-agent headers more descriptive

### DIFF
--- a/lib/unleash/configuration.rb
+++ b/lib/unleash/configuration.rb
@@ -51,6 +51,7 @@ module Unleash
 
     def http_headers
       {
+        'User-Agent' => "UnleashClientRuby/#{Unleash::VERSION} #{RUBY_ENGINE}/#{RUBY_VERSION} [#{RUBY_PLATFORM}]",
         'UNLEASH-INSTANCEID' => self.instance_id,
         'UNLEASH-APPNAME' => self.app_name,
         'Unleash-Client-Spec' => '5.0.2'

--- a/spec/unleash/client_spec.rb
+++ b/spec/unleash/client_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Unleash::Client do
           'Accept' => '*/*',
           'Content-Type' => 'application/json',
           'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
-          'User-Agent' => 'Ruby',
+          'User-Agent' => "UnleashClientRuby/#{Unleash::VERSION} #{RUBY_ENGINE}/#{RUBY_VERSION} [#{RUBY_PLATFORM}]",
           'X-Api-Key' => '123'
         }
       )
@@ -22,7 +22,7 @@ RSpec.describe Unleash::Client do
           'Accept' => '*/*',
           'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
           'Content-Type' => 'application/json',
-          'User-Agent' => 'Ruby'
+          'User-Agent' => "UnleashClientRuby/#{Unleash::VERSION} #{RUBY_ENGINE}/#{RUBY_VERSION} [#{RUBY_PLATFORM}]"
         }
       )
       .to_return(status: 200, body: "", headers: {})
@@ -46,7 +46,7 @@ RSpec.describe Unleash::Client do
           'Content-Type' => 'application/json',
           'Unleash-Appname' => 'my-test-app',
           'Unleash-Instanceid' => 'rspec/test',
-          'User-Agent' => 'Ruby',
+          'User-Agent' => "UnleashClientRuby/#{Unleash::VERSION} #{RUBY_ENGINE}/#{RUBY_VERSION} [#{RUBY_PLATFORM}]",
           'X-Api-Key' => '123'
         }
       )
@@ -117,7 +117,7 @@ RSpec.describe Unleash::Client do
           'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
           'Unleash-Appname' => 'my-test-app',
           'Unleash-Instanceid' => 'rspec/test',
-          'User-Agent' => 'Ruby',
+          'User-Agent' => "UnleashClientRuby/#{Unleash::VERSION} #{RUBY_ENGINE}/#{RUBY_VERSION} [#{RUBY_PLATFORM}]",
           'X-Api-Key' => '123'
         }
       )
@@ -158,7 +158,7 @@ RSpec.describe Unleash::Client do
           'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
           'Unleash-Appname' => 'my-test-app',
           'Unleash-Instanceid' => 'rspec/test',
-          'User-Agent' => 'Ruby',
+          'User-Agent' => "UnleashClientRuby/#{Unleash::VERSION} #{RUBY_ENGINE}/#{RUBY_VERSION} [#{RUBY_PLATFORM}]",
           'X-Api-Key' => '123'
         }
       )
@@ -256,7 +256,7 @@ RSpec.describe Unleash::Client do
           'Accept' => '*/*',
           'Content-Type' => 'application/json',
           'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
-          'User-Agent' => 'Ruby',
+          'User-Agent' => "UnleashClientRuby/#{Unleash::VERSION} #{RUBY_ENGINE}/#{RUBY_VERSION} [#{RUBY_PLATFORM}]",
           'X-Api-Key' => '123'
         }
       )
@@ -270,7 +270,7 @@ RSpec.describe Unleash::Client do
           'Content-Type' => 'application/json',
           'Unleash-Appname' => 'my-test-app',
           'Unleash-Instanceid' => 'rspec/test',
-          'User-Agent' => 'Ruby',
+          'User-Agent' => "UnleashClientRuby/#{Unleash::VERSION} #{RUBY_ENGINE}/#{RUBY_VERSION} [#{RUBY_PLATFORM}]",
           'X-Api-Key' => '123'
         }
       )
@@ -304,7 +304,7 @@ RSpec.describe Unleash::Client do
           'Accept' => '*/*',
           'Content-Type' => 'application/json',
           'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
-          'User-Agent' => 'Ruby',
+          'User-Agent' => "UnleashClientRuby/#{Unleash::VERSION} #{RUBY_ENGINE}/#{RUBY_VERSION} [#{RUBY_PLATFORM}]",
           'X-Api-Key' => '123'
         }
       )
@@ -328,7 +328,7 @@ RSpec.describe Unleash::Client do
           'Content-Type' => 'application/json',
           'Unleash-Appname' => 'my-test-app',
           'Unleash-Instanceid' => 'rspec/test',
-          'User-Agent' => 'Ruby',
+          'User-Agent' => "UnleashClientRuby/#{Unleash::VERSION} #{RUBY_ENGINE}/#{RUBY_VERSION} [#{RUBY_PLATFORM}]",
           'X-Api-Key' => '123'
         }
       )
@@ -606,7 +606,7 @@ RSpec.describe Unleash::Client do
             'Content-Type' => 'application/json',
             'Unleash-Appname' => 'my-test-app',
             'Unleash-Instanceid' => 'rspec/test',
-            'User-Agent' => 'Ruby',
+            'User-Agent' => "UnleashClientRuby/#{Unleash::VERSION} #{RUBY_ENGINE}/#{RUBY_VERSION} [#{RUBY_PLATFORM}]",
             'X-Api-Key' => '123'
           }
         )
@@ -620,7 +620,7 @@ RSpec.describe Unleash::Client do
             'Content-Type' => 'application/json',
             'Unleash-Appname' => 'my-test-app',
             'Unleash-Instanceid' => 'rspec/test',
-            'User-Agent' => 'Ruby',
+            'User-Agent' => "UnleashClientRuby/#{Unleash::VERSION} #{RUBY_ENGINE}/#{RUBY_VERSION} [#{RUBY_PLATFORM}]",
             'X-Api-Key' => '123'
           }
         )

--- a/spec/unleash/configuration_spec.rb
+++ b/spec/unleash/configuration_spec.rb
@@ -146,7 +146,8 @@ RSpec.describe Unleash do
           'X-API-KEY' => '123',
           'UNLEASH-APPNAME' => 'test-app',
           'UNLEASH-INSTANCEID' => config.instance_id,
-          'Unleash-Client-Spec' => '5.0.2'
+          'Unleash-Client-Spec' => '5.0.2',
+          'User-Agent' => "UnleashClientRuby/#{Unleash::VERSION} #{RUBY_ENGINE}/#{RUBY_VERSION} [#{RUBY_PLATFORM}]"
         }
       )
       expect(custom_headers_proc).to have_received(:call).exactly(1).times

--- a/spec/unleash/metrics_reporter_spec.rb
+++ b/spec/unleash/metrics_reporter_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe Unleash::MetricsReporter do
           'Content-Type' => 'application/json',
           'Unleash-Appname' => 'my-test-app',
           'Unleash-Instanceid' => 'rspec/test',
-          'User-Agent' => 'Ruby'
+          'User-Agent' => "UnleashClientRuby/#{Unleash::VERSION} #{RUBY_ENGINE}/#{RUBY_VERSION} [#{RUBY_PLATFORM}]"
         }
       )
       .to_return(status: 200, body: "", headers: {})


### PR DESCRIPTION
## About the changes
include in user-agent:
- sdk version
- ruby version
- platform it is running on

did not use RUBY_DESCRIPTION as it is a bit too verbose.

## Discussion points
I would recommend getting this change in place, merged and released before #152 is merged. This should allow some sort of telemetry being in place.

I don't believe it is in the user's interest to hide this information from the server. Eventually, maybe, one could consider adding this to the registration phase in the payload as well.