### PR TITLE
chore: update github action

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -42,7 +42,7 @@ jobs:
     needs:
       - lint
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Ruby ${{ matrix.ruby-version }}
         uses: ruby/setup-ruby@v1
         with:


### PR DESCRIPTION
## About the changes
so it uses Node.js 20, as version 16 is getting deprecated.


## Discussion points
coverallsapp also needs to be updated, but it doesn't run in v20 upstream, so not much to do there.