### PR TITLE
feat: allow payload compression in POST requests

### DIFF
--- a/lib/unleash/util/http.rb
+++ b/lib/unleash/util/http.rb
@@ -1,5 +1,7 @@
 require 'net/http'
 require 'uri'
+require 'zlib'
+require 'stringio'
 
 module Unleash
   module Util
@@ -8,6 +10,7 @@ module Unleash
         http = http_connection(uri)
 
         request = Net::HTTP::Get.new(uri.request_uri, http_headers(etag, headers_override))
+        request.delete('Content-Encoding')
 
         http.request(request)
       end
@@ -16,7 +19,15 @@ module Unleash
         http = http_connection(uri)
 
         request = Net::HTTP::Post.new(uri.request_uri, http_headers)
-        request.body = body
+        request_body =
+          if request['Content-Encoding'] == 'gzip'
+            request_body_writer = Zlib::GzipWriter.new(StringIO.new)
+            request_body_writer << body
+            request_body_writer.close.string
+          else
+            body
+          end
+        request.body = request_body
 
         http.request(request)
       end
@@ -32,6 +43,7 @@ module Unleash
 
       # @param etag [String, nil]
       # @param headers_override [Hash, nil]
+      # @return [Hash]
       def self.http_headers(etag = nil, headers_override = nil)
         Unleash.logger.debug "ETag: #{etag}" unless etag.nil?
 


### PR DESCRIPTION
## About the changes
- only done if custom_http_headers config includes {'Content-Encoding' => 'gzip'}
- only allow gzip.
- 'Content-Encoding' header will get dropped in GET requests.
- undocumented feature.

## Discussion points

- could have used helper class for compressing/decompression in the style of [ActiveSuppport::Gzip](https://github.com/rails/rails/blob/6f0d1ad14b92b9f5906e44740fce8b4f1c7075dc/activesupport/lib/active_support/gzip.rb) 
- my guess is that for the vast majority of users this will not be worth enabling. But maybe for a few heavy users it could be useful. (therefore not documenting at the moment).
- not tested against a raw unleash-server. Does it support naively decompressing gzipped content?

Creating as a draft PR to gather feedback.