### PR TITLE
chore: no longer support MRI ruby 2.5 and jruby 9.2

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -30,14 +30,12 @@ jobs:
         ruby-version:
           - jruby-9.4
           - jruby-9.3
-          - jruby-9.2
           - 3.3
           - 3.2
           - 3.1
           - '3.0'
           - 2.7
           - 2.6
-          - 2.5
 
     needs:
       - lint

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,7 +1,7 @@
 # inherit_from: .rubocop_todo.yml
 
 AllCops:
-  TargetRubyVersion: 2.5
+  TargetRubyVersion: 2.6
 
 Naming/PredicateName:
   AllowedMethods:

--- a/README.md
+++ b/README.md
@@ -16,10 +16,8 @@ Leverage the [Unleash Server](https://github.com/Unleash/unleash) for powerful f
   * MRI 3.0
   * MRI 2.7
   * MRI 2.6
-  * MRI 2.5
   * jruby 9.4
   * jruby 9.3
-  * jruby 9.2
 
 ## Installation
 

--- a/unleash-client.gemspec
+++ b/unleash-client.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.bindir        = 'bin'
   spec.executables   = spec.files.grep(%r{^bin/unleash}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
-  spec.required_ruby_version = ">= 2.5"
+  spec.required_ruby_version = ">= 2.6"
 
   spec.add_dependency "murmurhash3", "~> 0.1.7"
 


### PR DESCRIPTION
## About the changes
As these have been EOL for many years now, and they no longer even build in modern macos. You really shouldn't be using this version of ruby at this day and age.

Expect support for MRI 2.7 and 3.0 to also be dropped in the future, as they are also EOL.


## Discussion points
I think it is ok to wait a bit more until depcecating MRI 2.6, 2.7 and 3.0... and Jruby 9.3 (which targets to be compatible with  MRI 2.6).

This fixes the current builds breaking due to the 2.5/9.2 version of ruby not even building in the latest macos builders, and feels like the cleanest solution to get the builds going again.