### PR TITLE
feat: extend metrics data

### DIFF
--- a/lib/unleash/client.rb
+++ b/lib/unleash/client.rb
@@ -119,7 +119,11 @@ module Unleash
         'sdkVersion': "unleash-client-ruby:" + Unleash::VERSION,
         'strategies': Unleash.strategies.keys,
         'started': Time.now.iso8601(Unleash::TIME_RESOLUTION),
-        'interval': Unleash.configuration.metrics_interval_in_millis
+        'interval': Unleash.configuration.metrics_interval_in_millis,
+        'platformName': RUBY_ENGINE,
+        'platformVersion': RUBY_VERSION,
+        'yggdrasilVersion': nil,
+        'specVersion': Unleash::CLIENT_SPECIFICATION_VERSION,
       }
     end
 

--- a/lib/unleash/client.rb
+++ b/lib/unleash/client.rb
@@ -123,7 +123,7 @@ module Unleash
         'platformName': RUBY_ENGINE,
         'platformVersion': RUBY_VERSION,
         'yggdrasilVersion': nil,
-        'specVersion': Unleash::CLIENT_SPECIFICATION_VERSION,
+        'specVersion': Unleash::CLIENT_SPECIFICATION_VERSION
       }
     end
 

--- a/lib/unleash/metrics_reporter.rb
+++ b/lib/unleash/metrics_reporter.rb
@@ -24,6 +24,10 @@ module Unleash
       report = {
         'appName': Unleash.configuration.app_name,
         'instanceId': Unleash.configuration.instance_id,
+        'platformName': RUBY_ENGINE,
+        'platformVersion': RUBY_VERSION,
+        'yggdrasilVersion': nil,
+        'specVersion': Unleash::CLIENT_SPECIFICATION_VERSION,
         'bucket': {
           'start': start.iso8601(Unleash::TIME_RESOLUTION),
           'stop': stop.iso8601(Unleash::TIME_RESOLUTION),

--- a/spec/unleash/configuration_spec.rb
+++ b/spec/unleash/configuration_spec.rb
@@ -185,5 +185,30 @@ RSpec.describe Unleash do
         )
       end.to raise_error(ArgumentError)
     end
+
+    it "should send metadata on registration" do
+      WebMock \
+        .stub_request(:get, "http://test-url/api/client/features")
+        .to_return(status: 200, body: "", headers: {})
+
+      WebMock \
+        .stub_request(:post, "http://test-url/api/client/register")
+        .to_return(status: 200, body: "", headers: {})
+
+      Unleash::Client.new(
+        url: 'http://test-url/api',
+        app_name: 'test-app'
+      )
+
+      expect(WebMock).to have_requested(:post, 'http://test-url/api/client/register')
+        .with(
+          body: hash_including(
+            yggdrasilVersion: nil,
+            specVersion: anything,
+            platformName: anything,
+            platformVersion: anything
+          )
+        )
+    end
   end
 end

--- a/spec/unleash/metrics_reporter_spec.rb
+++ b/spec/unleash/metrics_reporter_spec.rb
@@ -114,16 +114,6 @@ RSpec.describe Unleash::MetricsReporter do
 
   it "includes metadata in the report" do
     WebMock.stub_request(:post, "http://test-url/client/metrics")
-      .with(
-        headers: {
-          'Accept' => '*/*',
-          'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
-          'Content-Type' => 'application/json',
-          'Unleash-Appname' => 'my-test-app',
-          'Unleash-Instanceid' => 'rspec/test',
-          'User-Agent' => "UnleashClientRuby/#{Unleash::VERSION} #{RUBY_ENGINE}/#{RUBY_VERSION} [#{RUBY_PLATFORM}]"
-        }
-      )
       .to_return(status: 200, body: "", headers: {})
 
     Unleash.toggle_metrics = Unleash::Metrics.new

--- a/spec/unleash/metrics_reporter_spec.rb
+++ b/spec/unleash/metrics_reporter_spec.rb
@@ -111,4 +111,34 @@ RSpec.describe Unleash::MetricsReporter do
 
     expect(WebMock).to_not have_requested(:post, 'http://test-url/client/metrics')
   end
+
+  it "includes metadata in the report" do
+    WebMock.stub_request(:post, "http://test-url/client/metrics")
+      .with(
+        headers: {
+          'Accept' => '*/*',
+          'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+          'Content-Type' => 'application/json',
+          'Unleash-Appname' => 'my-test-app',
+          'Unleash-Instanceid' => 'rspec/test',
+          'User-Agent' => "UnleashClientRuby/#{Unleash::VERSION} #{RUBY_ENGINE}/#{RUBY_VERSION} [#{RUBY_PLATFORM}]"
+        }
+      )
+      .to_return(status: 200, body: "", headers: {})
+
+    Unleash.toggle_metrics = Unleash::Metrics.new
+    Unleash.toggle_metrics.increment('featureA', :yes)
+
+    metrics_reporter.post
+
+    expect(WebMock).to have_requested(:post, 'http://test-url/client/metrics')
+      .with(
+        body: hash_including(
+          yggdrasilVersion: nil,
+          specVersion: anything,
+          platformName: anything,
+          platformVersion: anything
+        )
+      )
+  end
 end


### PR DESCRIPTION
Adds engine metadata to both registration and metrics