### PR TITLE
feat: automatically generated instance_id

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,9 +44,9 @@ It is **required** to configure:
 
 Please substitute the example `'https://unleash.herokuapp.com/api'` for the url of your own instance.
 
-It is **highly recommended** to configure:
-- `instance_id` parameter with a unique identifier for the running instance.
+### instance_id
 
+As of version 6.0.0, `instance_id` is now an automatically generated read-only property.
 
 ```ruby
 Unleash.configure do |config|
@@ -84,7 +84,6 @@ Argument | Description | Required? |  Type |  Default Value|
 ---------|-------------|-----------|-------|---------------|
 `url`      | Unleash server URL. | Y | String | N/A |
 `app_name` | Name of your program. | Y | String | N/A |
-`instance_id` | Identifier for the running instance of program. Important so you can trace back to where metrics are being collected from. **Highly recommended be be set.** | N | String | random UUID |
 `environment` | Unleash context option. Could be for example `prod` or `dev`. Not yet in use. **Not** the same as the SDK's [Unleash environment](https://docs.getunleash.io/reference/environments). | N | String | `default` |
 `project_name` | Name of the project to retrieve features from. If not set, all feature flags will be retrieved. | N | String | nil |
 `refresh_interval` | How often the unleash client should check with the server for configuration changes. | N | Integer |  15 |
@@ -142,7 +141,6 @@ Put in `config/initializers/unleash.rb`:
 Unleash.configure do |config|
   config.app_name = Rails.application.class.parent.to_s
   config.url      = 'https://unleash.herokuapp.com/api'
-  # config.instance_id = "#{Socket.gethostname}"
   config.logger   = Rails.logger
 end
 
@@ -151,10 +149,6 @@ UNLEASH = Unleash::Client.new
 # Or if preferred:
 # Rails.configuration.unleash = Unleash::Client.new
 ```
-For `config.instance_id` use a string with a unique identification for the running instance.
-For example: it could be the hostname, if you only run one App per host.
-Or the docker container id, if you are running in docker.
-If it is not set the client will generate an unique UUID for each execution.
 
 To have it available in the `rails console` command as well, also add to the file above:
 ```ruby
@@ -248,7 +242,6 @@ PhusionPassenger.on_event(:starting_worker_process) do |forked|
   if forked
     Unleash.configure do |config|
       config.app_name    = Rails.application.class.parent.to_s
-      # config.instance_id = "#{Socket.gethostname}"
       config.logger      = Rails.logger
       config.url                 = 'https://unleash.herokuapp.com/api'
       config.custom_http_headers = {'Authorization': '<API token>'}

--- a/examples/bootstrap.rb
+++ b/examples/bootstrap.rb
@@ -10,7 +10,6 @@ puts ">> START bootstrap.rb"
   url: 'https://unleash.herokuapp.com/api',
   custom_http_headers: { 'Authorization': '943ca9171e2c884c545c5d82417a655fb77cec970cc3b78a8ff87f4406b495d0' },
   app_name: 'bootstrap-test',
-  instance_id: 'local-test-cli',
   refresh_interval: 2,
   disable_client: true,
   disable_metrics: true,

--- a/examples/simple.rb
+++ b/examples/simple.rb
@@ -21,7 +21,6 @@ puts ">> START simple.rb"
   url: 'https://unleash.herokuapp.com/api',
   custom_http_headers: { 'Authorization': '943ca9171e2c884c545c5d82417a655fb77cec970cc3b78a8ff87f4406b495d0' },
   app_name: 'simple-test',
-  instance_id: 'local-test-cli',
   refresh_interval: 2,
   metrics_interval: 2,
   retry_limit: 2

--- a/lib/unleash/configuration.rb
+++ b/lib/unleash/configuration.rb
@@ -11,7 +11,6 @@ module Unleash
       :url,
       :app_name,
       :environment,
-      :instance_id,
       :project_name,
       :custom_http_headers,
       :disable_client,
@@ -26,9 +25,14 @@ module Unleash
       :bootstrap_config,
       :strategies
 
+    attr_reader \
+      :instance_id
+
     def initialize(opts = {})
       validate_custom_http_headers!(opts[:custom_http_headers]) if opts.has_key?(:custom_http_headers)
       set_defaults
+
+      @instance_id = SecureRandom.uuid
 
       initialize_default_logger if opts[:logger].nil?
 
@@ -89,7 +93,6 @@ module Unleash
       self.app_name         = nil
       self.environment      = 'default'
       self.url              = nil
-      self.instance_id      = SecureRandom.uuid
       self.project_name     = nil
       self.disable_client   = false
       self.disable_metrics  = false

--- a/spec/unleash/bootstrap/handler_spec.rb
+++ b/spec/unleash/bootstrap/handler_spec.rb
@@ -5,7 +5,6 @@ RSpec.describe Unleash::Bootstrap::Handler do
   Unleash.configure do |config|
     config.url      = 'http://unleash-url/'
     config.app_name = 'my-test-app'
-    config.instance_id = 'rspec/test'
     config.custom_http_headers = { 'X-API-KEY' => '123' }
   end
 

--- a/spec/unleash/client_spec.rb
+++ b/spec/unleash/client_spec.rb
@@ -45,7 +45,6 @@ RSpec.describe Unleash::Client do
           'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
           'Content-Type' => 'application/json',
           'Unleash-Appname' => 'my-test-app',
-          'Unleash-Instanceid' => 'rspec/test',
           'User-Agent' => "UnleashClientRuby/#{Unleash::VERSION} #{RUBY_ENGINE}/#{RUBY_VERSION} [#{RUBY_PLATFORM}]",
           'X-Api-Key' => '123'
         }
@@ -55,14 +54,12 @@ RSpec.describe Unleash::Client do
     Unleash.configure do |config|
       config.url      = 'http://test-url/'
       config.app_name = 'my-test-app'
-      config.instance_id = 'rspec/test'
       config.custom_http_headers = { 'X-API-KEY' => '123' }
     end
 
     unleash_client = Unleash::Client.new(
       url: 'http://test-url/',
       app_name: 'my-test-app',
-      instance_id: 'rspec/test',
       custom_http_headers: { 'X-API-KEY' => '123' }
     )
 
@@ -73,14 +70,14 @@ RSpec.describe Unleash::Client do
       .with(headers: { 'Content-Type': 'application/json' })
       .with(headers: { 'X-API-KEY': '123', 'Content-Type': 'application/json' })
       .with(headers: { 'UNLEASH-APPNAME': 'my-test-app' })
-      .with(headers: { 'UNLEASH-INSTANCEID': 'rspec/test' })
+      .with(headers: { 'UNLEASH-INSTANCEID': Unleash.configuration.instance_id })
     ).to have_been_made.once
 
     expect(
       a_request(:get, "http://test-url/client/features")
       .with(headers: { 'X-API-KEY': '123' })
       .with(headers: { 'UNLEASH-APPNAME': 'my-test-app' })
-      .with(headers: { 'UNLEASH-INSTANCEID': 'rspec/test' })
+      .with(headers: { 'UNLEASH-INSTANCEID': Unleash.configuration.instance_id })
     ).to have_been_made.once
 
     # Test now sending of metrics
@@ -91,7 +88,7 @@ RSpec.describe Unleash::Client do
         .with(headers: { 'Content-Type': 'application/json' })
         .with(headers: { 'X-API-KEY': '123', 'Content-Type': 'application/json' })
         .with(headers: { 'UNLEASH-APPNAME': 'my-test-app' })
-        .with(headers: { 'UNLEASH-INSTANCEID': 'rspec/test' })
+        .with(headers: { 'UNLEASH-INSTANCEID': Unleash.configuration.instance_id })
     ).not_to have_been_made
 
     # Sending metrics, if they have been evaluated:
@@ -103,7 +100,7 @@ RSpec.describe Unleash::Client do
       .with(headers: { 'Content-Type': 'application/json' })
       .with(headers: { 'X-API-KEY': '123', 'Content-Type': 'application/json' })
       .with(headers: { 'UNLEASH-APPNAME': 'my-test-app' })
-      .with(headers: { 'UNLEASH-INSTANCEID': 'rspec/test' })
+      .with(headers: { 'UNLEASH-INSTANCEID': Unleash.configuration.instance_id })
       .with{ |request| JSON.parse(request.body)['bucket']['toggles']['Feature.A']['yes'] == 2 }
     ).to have_been_made.once
   end
@@ -116,7 +113,7 @@ RSpec.describe Unleash::Client do
           'Content-Type' => 'application/json',
           'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
           'Unleash-Appname' => 'my-test-app',
-          'Unleash-Instanceid' => 'rspec/test',
+          'Unleash-Instanceid' => Unleash.configuration.instance_id,
           'User-Agent' => "UnleashClientRuby/#{Unleash::VERSION} #{RUBY_ENGINE}/#{RUBY_VERSION} [#{RUBY_PLATFORM}]",
           'X-Api-Key' => '123'
         }
@@ -157,7 +154,7 @@ RSpec.describe Unleash::Client do
           'Content-Type' => 'application/json',
           'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
           'Unleash-Appname' => 'my-test-app',
-          'Unleash-Instanceid' => 'rspec/test',
+          'Unleash-Instanceid' => Unleash.configuration.instance_id,
           'User-Agent' => "UnleashClientRuby/#{Unleash::VERSION} #{RUBY_ENGINE}/#{RUBY_VERSION} [#{RUBY_PLATFORM}]",
           'X-Api-Key' => '123'
         }
@@ -167,7 +164,6 @@ RSpec.describe Unleash::Client do
     Unleash.configure do |config|
       config.url      = 'http://test-url/'
       config.app_name = 'my-test-app'
-      config.instance_id = 'rspec/test'
       config.disable_metrics = true
       config.custom_http_headers = { 'X-API-KEY' => '123' }
       config.log_level = Logger::DEBUG
@@ -216,7 +212,6 @@ RSpec.describe Unleash::Client do
     Unleash.configure do |config|
       config.url      = 'http://test-url/'
       config.app_name = 'my-test-app'
-      config.instance_id = 'rspec/test'
       config.disable_client = true
       config.disable_metrics = true
       config.custom_http_headers = { 'X-API-KEY' => '123' }
@@ -269,7 +264,7 @@ RSpec.describe Unleash::Client do
           'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
           'Content-Type' => 'application/json',
           'Unleash-Appname' => 'my-test-app',
-          'Unleash-Instanceid' => 'rspec/test',
+          'Unleash-Instanceid' => Unleash.configuration.instance_id,
           'User-Agent' => "UnleashClientRuby/#{Unleash::VERSION} #{RUBY_ENGINE}/#{RUBY_VERSION} [#{RUBY_PLATFORM}]",
           'X-Api-Key' => '123'
         }
@@ -279,7 +274,6 @@ RSpec.describe Unleash::Client do
     Unleash.configure do |config|
       config.url      = 'http://test-url/'
       config.app_name = 'my-test-app'
-      config.instance_id = 'rspec/test'
       config.disable_client = false
       config.disable_metrics = true
       config.custom_http_headers = { 'X-API-KEY' => '123' }
@@ -327,7 +321,7 @@ RSpec.describe Unleash::Client do
           'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
           'Content-Type' => 'application/json',
           'Unleash-Appname' => 'my-test-app',
-          'Unleash-Instanceid' => 'rspec/test',
+          'Unleash-Instanceid' => Unleash.configuration.instance_id,
           'User-Agent' => "UnleashClientRuby/#{Unleash::VERSION} #{RUBY_ENGINE}/#{RUBY_VERSION} [#{RUBY_PLATFORM}]",
           'X-Api-Key' => '123'
         }
@@ -337,7 +331,6 @@ RSpec.describe Unleash::Client do
     Unleash.configure do |config|
       config.url      = 'http://test-url/'
       config.app_name = 'my-test-app'
-      config.instance_id = 'rspec/test'
       config.disable_client = false
       config.disable_metrics = true
       config.custom_http_headers = { 'X-API-KEY' => '123' }
@@ -357,7 +350,6 @@ RSpec.describe Unleash::Client do
     Unleash.configure do |config|
       config.url      = 'http://test-url/'
       config.app_name = 'my-test-app'
-      config.instance_id = 'rspec/test'
       config.disable_client = true
       config.disable_metrics = false
       config.custom_http_headers = { 'X-API-KEY' => '123' }
@@ -605,7 +597,7 @@ RSpec.describe Unleash::Client do
             'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
             'Content-Type' => 'application/json',
             'Unleash-Appname' => 'my-test-app',
-            'Unleash-Instanceid' => 'rspec/test',
+            'Unleash-Instanceid' => Unleash.configuration.instance_id,
             'User-Agent' => "UnleashClientRuby/#{Unleash::VERSION} #{RUBY_ENGINE}/#{RUBY_VERSION} [#{RUBY_PLATFORM}]",
             'X-Api-Key' => '123'
           }
@@ -619,7 +611,7 @@ RSpec.describe Unleash::Client do
             'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
             'Content-Type' => 'application/json',
             'Unleash-Appname' => 'my-test-app',
-            'Unleash-Instanceid' => 'rspec/test',
+            'Unleash-Instanceid' => Unleash.configuration.instance_id,
             'User-Agent' => "UnleashClientRuby/#{Unleash::VERSION} #{RUBY_ENGINE}/#{RUBY_VERSION} [#{RUBY_PLATFORM}]",
             'X-Api-Key' => '123'
           }

--- a/spec/unleash/metrics_reporter_spec.rb
+++ b/spec/unleash/metrics_reporter_spec.rb
@@ -13,7 +13,6 @@ RSpec.describe Unleash::MetricsReporter do
 
     Unleash.configuration.url         = 'http://test-url/'
     Unleash.configuration.app_name    = 'my-test-app'
-    Unleash.configuration.instance_id = 'rspec/test'
 
     # Do not test the scheduled calls from client/metrics:
     Unleash.configuration.disable_client = true
@@ -24,7 +23,6 @@ RSpec.describe Unleash::MetricsReporter do
     Unleash.configure do |config|
       config.url      = 'http://test-url/'
       config.app_name = 'my-test-app'
-      config.instance_id = 'rspec/test'
       config.disable_client = true
     end
     Unleash.toggle_metrics = Unleash::Metrics.new
@@ -68,7 +66,7 @@ RSpec.describe Unleash::MetricsReporter do
           'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
           'Content-Type' => 'application/json',
           'Unleash-Appname' => 'my-test-app',
-          'Unleash-Instanceid' => 'rspec/test',
+          'Unleash-Instanceid' => Unleash.configuration.instance_id,
           'User-Agent' => "UnleashClientRuby/#{Unleash::VERSION} #{RUBY_ENGINE}/#{RUBY_VERSION} [#{RUBY_PLATFORM}]"
         }
       )
@@ -99,7 +97,7 @@ RSpec.describe Unleash::MetricsReporter do
       .with(
         body: hash_including(
           appName: "my-test-app",
-          instanceId: "rspec/test"
+          instanceId: Unleash.configuration.instance_id
         )
       )
   end

--- a/spec/unleash/scheduled_executor_spec.rb
+++ b/spec/unleash/scheduled_executor_spec.rb
@@ -35,18 +35,18 @@ RSpec.describe Unleash::ScheduledExecutor do
     max_exceptions = 1
 
     scheduled_executor = Unleash::ScheduledExecutor.new('TesterLoop', 0, max_exceptions)
-    new_instance_id = SecureRandom.uuid
-    original_instance_id = Unleash.configuration.instance_id
+    new_app_name = SecureRandom.uuid
+    original_app_name = Unleash.configuration.app_name
 
     scheduled_executor.run do
-      Unleash.configuration.instance_id = new_instance_id
+      Unleash.configuration.app_name = new_app_name
       raise StopIteration
     end
 
     scheduled_executor.thread.join
-    expect(Unleash.configuration.instance_id).to eq(new_instance_id)
+    expect(Unleash.configuration.app_name).to eq(new_app_name)
 
-    Unleash.configuration.instance_id = original_instance_id
+    Unleash.configuration.app_name = original_app_name
   end
 
   # These two tests are super flaky because they're checking if threading works
@@ -55,39 +55,39 @@ RSpec.describe Unleash::ScheduledExecutor do
     max_exceptions = 1
 
     scheduled_executor = Unleash::ScheduledExecutor.new('TesterLoop', 0.02, max_exceptions, true)
-    new_instance_id = SecureRandom.uuid
-    original_instance_id = Unleash.configuration.instance_id
+    new_app_name = SecureRandom.uuid
+    original_app_name = Unleash.configuration.app_name
 
     scheduled_executor.run do
-      Unleash.configuration.instance_id = new_instance_id
+      Unleash.configuration.app_name = new_app_name
       raise StopIteration
     end
 
     sleep 0.01
 
-    expect(Unleash.configuration.instance_id).to eq(new_instance_id)
+    expect(Unleash.configuration.app_name).to eq(new_app_name)
     scheduled_executor.thread.join
 
-    Unleash.configuration.instance_id = original_instance_id
+    Unleash.configuration.app_name = original_app_name
   end
 
   xit "will not trigger immediate exection when not set" do
     max_exceptions = 1
 
     scheduled_executor = Unleash::ScheduledExecutor.new('TesterLoop', 0.02, max_exceptions, false)
-    new_instance_id = SecureRandom.uuid
-    original_instance_id = Unleash.configuration.instance_id
+    new_app_name = SecureRandom.uuid
+    original_app_name = Unleash.configuration.app_name
 
     scheduled_executor.run do
-      Unleash.configuration.instance_id = new_instance_id
+      Unleash.configuration.app_name = new_app_name
       raise StopIteration
     end
 
     sleep 0.01
 
-    expect(Unleash.configuration.instance_id).to eq(original_instance_id)
+    expect(Unleash.configuration.app_name).to eq(original_app_name)
     scheduled_executor.thread.join
 
-    Unleash.configuration.instance_id = original_instance_id
+    Unleash.configuration.app_name = original_app_name
   end
 end


### PR DESCRIPTION
https://linear.app/unleash/issue/2-2392/make-instance-id-autogenned-ruby

This makes `instance_id` an automatically generated read-only property, instead of being set by the user.

Similar to https://github.com/Unleash/unleash-client-dotnet/pull/226