### PR TITLE
chore: emit warning when overriding a built in strategy

### DIFF
--- a/lib/unleash/strategies.rb
+++ b/lib/unleash/strategies.rb
@@ -24,8 +24,10 @@ module Unleash
 
     def add(strategy)
       if default_strategy_names.include?(strategy.name)
+        # rubocop:disable Style/StderrPuts
         $stderr.puts "Warning: Overriding built in strategy '#{strategy.name}'. Overriding built in strategies is deprecated and will be \
         removed in a future release."
+        # rubocop:enable Style/StderrPuts
       end
       self.internal_add(strategy)
     end

--- a/lib/unleash/strategies.rb
+++ b/lib/unleash/strategies.rb
@@ -24,7 +24,8 @@ module Unleash
 
     def add(strategy)
       if default_strategy_names.include?(strategy.name)
-        $stderr.puts "Warning: Overriding built in strategy '#{strategy.name}'. Overriding built in strategies is deprecated and will be removed in a future release."
+        $stderr.puts "Warning: Overriding built in strategy '#{strategy.name}'. Overriding built in strategies is deprecated and will be \
+        removed in a future release."
       end
       self.internal_add(strategy)
     end
@@ -68,7 +69,7 @@ module Unleash
     end
 
     def default_strategy_names
-      DEFAULT_STRATEGIES.map { |strategy_class| strategy_class.new.name }
+      DEFAULT_STRATEGIES.map{ |strategy_class| strategy_class.new.name }
     end
 
     DEFAULT_STRATEGIES = [

--- a/lib/unleash/strategies.rb
+++ b/lib/unleash/strategies.rb
@@ -24,10 +24,8 @@ module Unleash
 
     def add(strategy)
       if default_strategy_names.include?(strategy.name)
-        # rubocop:disable Style/StderrPuts
-        $stderr.puts "Warning: Overriding built in strategy '#{strategy.name}'. Overriding built in strategies is deprecated and will be \
-        removed in a future release."
-        # rubocop:enable Style/StderrPuts
+        Unleash.logger.error "Warning: Overriding built in strategy '#{strategy.name}'. Overriding built in strategies is \
+deprecated and will be removed in a future release."
       end
       self.internal_add(strategy)
     end

--- a/lib/unleash/strategies.rb
+++ b/lib/unleash/strategies.rb
@@ -24,8 +24,8 @@ module Unleash
 
     def add(strategy)
       if default_strategy_names.include?(strategy.name)
-        Unleash.logger.error "Warning: Overriding built in strategy '#{strategy.name}'. Overriding built in strategies is \
-deprecated and will be removed in a future release."
+        Unleash.logger.error "WARNING: Overriding built in strategy '#{strategy.name}'. OVERIDING BUILT IN STRATEGIES IS \
+DEPRECATED AND WILL BE REMOVED IN A FUTURE RELEASE."
       end
       self.internal_add(strategy)
     end

--- a/lib/unleash/strategies.rb
+++ b/lib/unleash/strategies.rb
@@ -23,7 +23,10 @@ module Unleash
     end
 
     def add(strategy)
-      @strategies[strategy.name] = strategy
+      if default_strategy_names.include?(strategy.name)
+        $stderr.puts "Warning: Overriding built in strategy '#{strategy.name}'. Overriding built in strategies is deprecated and will be removed in a future release."
+      end
+      self.internal_add(strategy)
     end
 
     def []=(key, strategy)
@@ -52,12 +55,20 @@ module Unleash
         .each do |c|
         strategy = c.new
         warn_deprecated_registration(strategy, 'adding custom class into Unleash::Strategy namespace')
-        self.add(strategy)
+        self.internal_add(strategy)
       end
     end
 
     def register_base_strategies
-      DEFAULT_STRATEGIES.each{ |c| self.add(c.new) }
+      DEFAULT_STRATEGIES.each{ |c| self.internal_add(c.new) }
+    end
+
+    def internal_add(strategy)
+      @strategies[strategy.name] = strategy
+    end
+
+    def default_strategy_names
+      DEFAULT_STRATEGIES.map { |strategy_class| strategy_class.new.name }
     end
 
     DEFAULT_STRATEGIES = [


### PR DESCRIPTION
This emits a std error line when overriding a built in strategy. That's not good behavior. This is just being polite and giving users some breathing room to stop doing that

This is a bit hacky but the intent here is to get people off this behavior so we can merge Yggdrasil (this is effectively the only breaking change that Yggdrasil will cause). Ultimately this code will go away anyway when that's merged so... eh