### PR TITLE
fix: do not fail when case insentive enabled while having a complex context object

### DIFF
--- a/examples/complex-properties-case-insensitive.json
+++ b/examples/complex-properties-case-insensitive.json
@@ -1,0 +1,49 @@
+{
+  "version": 2,
+  "features": [
+    {
+      "name": "4343443",
+      "type": "release",
+      "enabled": true,
+      "project": "ruby-test",
+      "stale": false,
+      "strategies": [
+        {
+          "name": "flexibleRollout",
+          "constraints": [
+            {
+              "values": [
+                "bar"
+              ],
+              "inverted": false,
+              "operator": "STR_CONTAINS",
+              "contextName": "fancy",
+              "caseInsensitive": true
+            }
+          ],
+          "parameters": {
+            "groupId": "4343443",
+            "rollout": "100",
+            "stickiness": "default"
+          },
+          "variants": []
+        }
+      ],
+      "variants": [],
+      "description": null,
+      "impressionData": false
+    }
+  ],
+  "query": {
+    "project": [
+      "ruby-test"
+    ],
+    "environment": "development",
+    "inlineSegmentConstraints": true
+  },
+  "meta": {
+    "revisionId": 658,
+    "etag": "\"0cc4db4e:658\"",
+    "queryHash": "0cc4db4e"
+  }
+}

--- a/examples/complex_properties_with_case_insensitive.rb
+++ b/examples/complex_properties_with_case_insensitive.rb
@@ -1,0 +1,47 @@
+#!/usr/bin/env ruby
+
+require 'unleash'
+require 'unleash/context'
+
+puts ">> START complex_properties_with_case_insensitive.rb"
+
+@unleash = Unleash::Client.new(
+  url: 'https://x.x.com/api',
+  custom_http_headers: { 'Authorization': 'invalid' },
+  app_name: 'simple-test',
+  instance_id: 'local-test-cli',
+  disable_client: true,
+  disable_metrics: true,
+  bootstrap_config: Unleash::Bootstrap::Configuration.new(file_path: "examples/complex-properties-case-insensitive.json")
+)
+
+context_params = {
+  user_id: '123',
+  session_id: 'verylongsesssionid',
+  remote_address: '127.0.0.3',
+  properties: {
+    fancy: { foo: { "bar" => "baz" } }
+  }
+}
+
+# feature_name = "AwesomeFeature"
+feature_name = "4343443"
+unleash_context = Unleash::Context.new(context_params)
+#unleash_context.user_id = 123
+
+sleep 1
+if @unleash.is_enabled?(feature_name, unleash_context)
+  puts "> #{feature_name} is enabled"
+else
+  puts "> #{feature_name} is not enabled"
+end
+sleep 1
+puts "---"
+puts ""
+puts ""
+
+puts "> shutting down client..."
+
+@unleash.shutdown
+
+puts ">> END complex_properties_with_case_insensitive.rb"


### PR DESCRIPTION
## About the changes
First commit includes a test to validate it fails

Closes #189

