### PR TITLE
feat: add segments to new feature toggle

### DIFF
--- a/lib/unleash/client.rb
+++ b/lib/unleash/client.rb
@@ -80,7 +80,7 @@ module Unleash
         return fallback_variant
       end
 
-      toggle = Unleash::FeatureToggle.new(toggle_as_hash)
+      toggle = Unleash::FeatureToggle.new(toggle_as_hash, Unleash&.segment_cache)
       variant = toggle.get_variant(context, fallback_variant)
 
       if variant.nil?


### PR DESCRIPTION
## About the changes
I added an optional second parameter Unleash&.segment_cache to the initialization of the method `Unleash::FeatureToggle.new(toggle_as_hash, Unleash&.segment_cache)`.

## Discussion points
Is there another alternative for segments to be considered when querying variant ?
