### PR TITLE
chore: add feature_enabled property to variants

### DIFF
--- a/lib/unleash/feature_toggle.rb
+++ b/lib/unleash/feature_toggle.rb
@@ -48,11 +48,14 @@ module Unleash
 
       choice = evaluation_result.enabled? ? :yes : :no
       Unleash.toggle_metrics.increment_variant(self.name, choice, variant.name) unless Unleash.configuration.disable_metrics
+
+      variant.feature_enabled = evaluation_result.enabled? || false
+
       variant
     end
 
     def self.disabled_variant
-      Unleash::Variant.new(name: 'disabled', enabled: false)
+      Unleash::Variant.new(name: 'disabled', enabled: false, feature_enabled: false)
     end
 
     private

--- a/lib/unleash/feature_toggle.rb
+++ b/lib/unleash/feature_toggle.rb
@@ -49,7 +49,7 @@ module Unleash
       choice = evaluation_result.enabled? ? :yes : :no
       Unleash.toggle_metrics.increment_variant(self.name, choice, variant.name) unless Unleash.configuration.disable_metrics
 
-      variant.feature_enabled = evaluation_result.enabled? || false
+      variant.feature_enabled = evaluation_result.enabled?
 
       variant
     end

--- a/lib/unleash/spec_version.rb
+++ b/lib/unleash/spec_version.rb
@@ -1,3 +1,3 @@
 module Unleash
-  CLIENT_SPECIFICATION_VERSION = "5.0.2".freeze
+  CLIENT_SPECIFICATION_VERSION = "5.1.0".freeze
 end

--- a/lib/unleash/variant.rb
+++ b/lib/unleash/variant.rb
@@ -1,6 +1,6 @@
 module Unleash
   class Variant
-    attr_accessor :name, :enabled, :payload
+    attr_accessor :name, :enabled, :payload, :feature_enabled
 
     def initialize(params = {})
       raise ArgumentError, "Variant initializer requires a hash." unless params.is_a?(Hash)
@@ -8,16 +8,17 @@ module Unleash
       self.name = params.values_at('name', :name).compact.first
       self.enabled = params.values_at('enabled', :enabled).compact.first || false
       self.payload = params.values_at('payload', :payload).compact.first
+      self.feature_enabled = params.values_at('feature_enabled', :feature_enabled).compact.first || false
 
       raise ArgumentError, "Variant requires a name." if self.name.nil?
     end
 
     def to_s
-      "<Variant: name=#{self.name},enabled=#{self.enabled},payload=#{self.payload}>"
+      "<Variant: name=#{self.name},enabled=#{self.enabled},payload=#{self.payload},feature_enabled=#{self.feature_enabled}>"
     end
 
     def ==(other)
-      self.name == other.name && self.enabled == other.enabled && self.payload == other.payload
+      self.name == other.name && self.enabled == other.enabled && self.payload == other.payload && self.feature_enabled == other.feature_enabled
     end
   end
 end

--- a/lib/unleash/variant.rb
+++ b/lib/unleash/variant.rb
@@ -18,7 +18,8 @@ module Unleash
     end
 
     def ==(other)
-      self.name == other.name && self.enabled == other.enabled && self.payload == other.payload && self.feature_enabled == other.feature_enabled
+      self.name == other.name && self.enabled == other.enabled && self.payload == other.payload \
+        && self.feature_enabled == other.feature_enabled
     end
   end
 end

--- a/spec/unleash/configuration_spec.rb
+++ b/spec/unleash/configuration_spec.rb
@@ -146,7 +146,7 @@ RSpec.describe Unleash do
           'X-API-KEY' => '123',
           'UNLEASH-APPNAME' => 'test-app',
           'UNLEASH-INSTANCEID' => config.instance_id,
-          'Unleash-Client-Spec' => '5.0.2',
+          'Unleash-Client-Spec' => '5.1.0',
           'User-Agent' => "UnleashClientRuby/#{Unleash::VERSION} #{RUBY_ENGINE}/#{RUBY_VERSION} [#{RUBY_PLATFORM}]"
         }
       )


### PR DESCRIPTION
https://linear.app/unleash/issue/2-2638/feature-enabled-support-in-ruby-sdk

Adds a `feature_enabled` property to variants, similar to https://github.com/Unleash/unleash-client-python/pull/285

Also bumps the client spec to the respective version, so the expectation matches.