### PR TITLE
fix: variant stickiness from strategy

### DIFF
--- a/lib/unleash/spec_version.rb
+++ b/lib/unleash/spec_version.rb
@@ -1,3 +1,3 @@
 module Unleash
-  CLIENT_SPECIFICATION_VERSION = "5.1.0".freeze
+  CLIENT_SPECIFICATION_VERSION = "5.1.7".freeze
 end

--- a/spec/unleash/configuration_spec.rb
+++ b/spec/unleash/configuration_spec.rb
@@ -146,7 +146,7 @@ RSpec.describe Unleash do
           'X-API-KEY' => '123',
           'UNLEASH-APPNAME' => 'test-app',
           'UNLEASH-INSTANCEID' => config.instance_id,
-          'Unleash-Client-Spec' => '5.1.0',
+          'Unleash-Client-Spec' => '5.1.7',
           'User-Agent' => "UnleashClientRuby/#{Unleash::VERSION} #{RUBY_ENGINE}/#{RUBY_VERSION} [#{RUBY_PLATFORM}]"
         }
       )


### PR DESCRIPTION
https://linear.app/unleash/issue/2-2644/correctly-resolve-variant-stickiness-from-strategy-in-ruby-sdk

When bumping the client spec in https://github.com/Unleash/unleash-client-ruby/pull/197 to the latest version I noticed we were not being 100% compliant. The reason for it seemed to be the fact that we're not respecting custom strategy stickiness when resolving variants, as running the spec tests multiple times sometimes returned the wrong variant in those tests.

See:
 - https://github.com/Unleash/unleash-client-node/pull/570
 - https://github.com/Unleash/unleash-client-dotnet/pull/212

This PR applies a similar change to the Ruby SDK, bumping the client spec to the latest version.