### PR TITLE
fix: update ruby SDK to increase the possible random numbers used for stickiness id

### DIFF
--- a/lib/unleash/strategy/flexible_rollout.rb
+++ b/lib/unleash/strategy/flexible_rollout.rb
@@ -40,7 +40,7 @@ module Unleash
       end
 
       def random
-        Random.rand(0..10000)
+        Random.rand(0..10_000)
       end
 
       def resolve_stickiness(stickiness, context)

--- a/lib/unleash/strategy/flexible_rollout.rb
+++ b/lib/unleash/strategy/flexible_rollout.rb
@@ -40,7 +40,7 @@ module Unleash
       end
 
       def random
-        Random.rand(0..100)
+        Random.rand(0..10000)
       end
 
       def resolve_stickiness(stickiness, context)

--- a/spec/unleash/strategy/flexible_rollout_spec.rb
+++ b/spec/unleash/strategy/flexible_rollout_spec.rb
@@ -99,5 +99,33 @@ RSpec.describe Unleash::Strategy::FlexibleRollout do
       expect(strategy.is_enabled?(params, custom_context)).to be_falsey
       expect(strategy.is_enabled?(params, nil)).to be_falsey
     end
+
+    it 'should deviate at most one percentage point from the rollout percentage' do
+      percentage = 25
+      params = {
+        'groupId' => 'groupId',
+        'rollout' => percentage,
+        'stickiness' => 'default'
+      }
+
+      rounds = 200_000
+      enabled_count = 0
+
+      rounds.times do |i|
+        params = { percentage: percentage, group_id: group_id }
+        context = { session_id: i }
+
+        if strategy.is_enabled?(params, context)
+          enabled_count += 1
+        end
+      end
+
+      actual_percentage = ((enabled_count.to_f / rounds) * 100).round
+      high_mark = percentage + 1
+      low_mark = percentage - 1
+
+      assert low_mark <= actual_percentage
+      assert high_mark >= actual_percentage
+    end
   end
 end

--- a/spec/unleash/strategy/flexible_rollout_spec.rb
+++ b/spec/unleash/strategy/flexible_rollout_spec.rb
@@ -102,9 +102,8 @@ RSpec.describe Unleash::Strategy::FlexibleRollout do
 
     it 'should deviate at most one percentage point from the rollout percentage' do
       percentage = 25
-      group_id = 'groupId'
       params = {
-        'groupId' => group_id,
+        'groupId' => 'groupId',
         'rollout' => percentage,
         'stickiness' => 'default'
       }
@@ -113,7 +112,6 @@ RSpec.describe Unleash::Strategy::FlexibleRollout do
       enabled_count = 0
 
       rounds.times do |i|
-        params = { percentage: percentage, group_id: group_id }
         context = { session_id: i }
 
         if strategy.is_enabled?(params, context)

--- a/spec/unleash/strategy/flexible_rollout_spec.rb
+++ b/spec/unleash/strategy/flexible_rollout_spec.rb
@@ -102,8 +102,9 @@ RSpec.describe Unleash::Strategy::FlexibleRollout do
 
     it 'should deviate at most one percentage point from the rollout percentage' do
       percentage = 25
+      group_id = 'groupId'
       params = {
-        'groupId' => 'groupId',
+        'groupId' => group_id,
         'rollout' => percentage,
         'stickiness' => 'default'
       }
@@ -124,8 +125,8 @@ RSpec.describe Unleash::Strategy::FlexibleRollout do
       high_mark = percentage + 1
       low_mark = percentage - 1
 
-      assert low_mark <= actual_percentage
-      assert high_mark >= actual_percentage
+      expect(low_mark <= actual_percentage).to be_truthy
+      expect(high_mark >= actual_percentage).to be_truthy
     end
   end
 end

--- a/spec/unleash/strategy/flexible_rollout_spec.rb
+++ b/spec/unleash/strategy/flexible_rollout_spec.rb
@@ -113,10 +113,7 @@ RSpec.describe Unleash::Strategy::FlexibleRollout do
 
       rounds.times do |i|
         context = { session_id: i }
-
-        if strategy.is_enabled?(params, context)
-          enabled_count += 1
-        end
+        enabled_count += 1 if strategy.is_enabled?(params, context)
       end
 
       actual_percentage = ((enabled_count.to_f / rounds) * 100).round


### PR DESCRIPTION
Same fix as done in some other sdks, such as the node one at
https://github.com/Unleash/unleash-client-node/pull/417

Fixes an issue where 1% rollout would not yield any results with
random rollout for certain group ids