### PR TITLE
fix: context now dumps to JSON correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,11 @@ Note: These changes are not considered notable:
 
 ## [Unreleased]
 
-## [6.0.5] - 2024-09-25
+## [6.0.7] - 2024-10-24
+#### Fixed
+- Context object correctly dumps to JSON
+
+## [6.0.6] - 2024-10-23
 #### Changed
 - Upgrade core engine library to allow ffi version 1.16.3
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Ruby client for the [Unleash](https://github.com/Unleash/unleash) feature manage
 Add this line to your application's Gemfile:
 
 ```ruby
-gem 'unleash', '~> 6.0.6'
+gem 'unleash', '~> 6.0.7'
 ```
 
 And then execute:

--- a/lib/unleash/context.rb
+++ b/lib/unleash/context.rb
@@ -23,7 +23,7 @@ module Unleash
       ",app_name=#{@app_name},environment=#{@environment},current_time=#{@current_time}>"
     end
 
-    def as_json
+    def as_json(*_options)
       {
         appName: to_safe_value(self.app_name),
         environment: to_safe_value(self.environment),

--- a/lib/unleash/version.rb
+++ b/lib/unleash/version.rb
@@ -1,3 +1,3 @@
 module Unleash
-  VERSION = "6.0.6".freeze
+  VERSION = "6.0.7".freeze
 end

--- a/spec/unleash/context_spec.rb
+++ b/spec/unleash/context_spec.rb
@@ -189,4 +189,8 @@ RSpec.describe Unleash::Context do
     context = Unleash::Context.new(params)
     expect(context.to_h).to eq(params)
   end
+
+  it "converts to json when options are set" do
+    expect { JSON.dump(Unleash::Context.new) }.not_to raise_error
+  end
 end

--- a/spec/unleash/context_spec.rb
+++ b/spec/unleash/context_spec.rb
@@ -190,7 +190,7 @@ RSpec.describe Unleash::Context do
     expect(context.to_h).to eq(params)
   end
 
-  it "converts to json when options are set" do
+  it "converts to json without error" do
     expect { JSON.dump(Unleash::Context.new) }.not_to raise_error
   end
 end


### PR DESCRIPTION
Previously we weren't passing the options which causes an incorrect number of args error