### PR TITLE
fix: aarch64 support

### DIFF
--- a/lib/unleash/version.rb
+++ b/lib/unleash/version.rb
@@ -1,3 +1,3 @@
 module Unleash
-  VERSION = "6.0.8.beta.1".freeze
+  VERSION = "6.0.8".freeze
 end

--- a/lib/unleash/version.rb
+++ b/lib/unleash/version.rb
@@ -1,3 +1,3 @@
 module Unleash
-  VERSION = "6.0.7".freeze
+  VERSION = "6.0.8.beta.1".freeze
 end

--- a/unleash-client.gemspec
+++ b/unleash-client.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
   spec.required_ruby_version = ">= 2.7"
 
-  spec.add_dependency "yggdrasil-engine", "~> 0.0.7"
+  spec.add_dependency "yggdrasil-engine", "~> 0.0.9"
 
   spec.add_development_dependency "bundler", "~> 2.1"
   spec.add_development_dependency "rake", "~> 12.3"


### PR DESCRIPTION
Resolves Yggdrasil core to a version that contains the correct binary for aarch64