### PR TITLE
fix: response encode mismatch

### DIFF
--- a/lib/unleash/util/http.rb
+++ b/lib/unleash/util/http.rb
@@ -24,6 +24,7 @@ module Unleash
       def self.http_connection(uri)
         http = Net::HTTP.new(uri.host, uri.port)
         http.use_ssl = true if uri.scheme == 'https'
+        http.response_body_encoding = 'UTF-8'
         http.open_timeout = Unleash.configuration.timeout # in seconds
         http.read_timeout = Unleash.configuration.timeout # in seconds
 

--- a/lib/unleash/util/http.rb
+++ b/lib/unleash/util/http.rb
@@ -24,7 +24,7 @@ module Unleash
       def self.http_connection(uri)
         http = Net::HTTP.new(uri.host, uri.port)
         http.use_ssl = true if uri.scheme == 'https'
-        http.response_body_encoding = 'UTF-8'
+        http.response_body_encoding = 'UTF-8' if http.respond_to?(:response_body_encoding=)
         http.open_timeout = Unleash.configuration.timeout # in seconds
         http.read_timeout = Unleash.configuration.timeout # in seconds
 


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes
<!-- Describe the changes introduced. What are they and why are they being introduced? Feel free to also add screenshots or steps to view the changes if they're visual. -->
Ruby's file writing defaults to utf-8, but net http's response seems to be based on the header and ASCII is used by default when no specification is made.
I didn't write any test files, but I verified them as follows:

```
# run with main branch
bin/spring stop
bin/rails c
> Unleash::Client.new
[Unleash] ERROR: Unable to save backup file. Exception thrown Encoding::UndefinedConversionError:'"\xE3" from ASCII-8BIT to UTF-8'
...
# run with this branch
bin/spring stop
bin/rails c
> Unleash::Client.new
(no error)
```
<!-- Does it close an issue? Multiple? -->
Closes  #214

<!-- (For internal contributors): Does it relate to an issue on public roadmap? -->
<!--
Relates to [roadmap](https://github.com/orgs/Unleash/projects/10) item: #
-->

### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
