### PR TITLE
test: what happens if longest without a report is false

### DIFF
--- a/lib/unleash/metrics_reporter.rb
+++ b/lib/unleash/metrics_reporter.rb
@@ -32,7 +32,7 @@ module Unleash
       Unleash.logger.debug "post() Report"
 
       bucket = self.generate_report
-      if bucket.nil? && !(Time.now - self.last_time < LONGEST_WITHOUT_A_REPORT) # and last time is less then 10 minutes...
+      if bucket.nil? && (Time.now - self.last_time >= LONGEST_WITHOUT_A_REPORT) # and last time is less then 10 minutes...
         Unleash.logger.debug "Report not posted to server, as it would have been empty. (and has been empty for up to 10 min)"
 
         return

--- a/lib/unleash/metrics_reporter.rb
+++ b/lib/unleash/metrics_reporter.rb
@@ -32,7 +32,7 @@ module Unleash
       Unleash.logger.debug "post() Report"
 
       bucket = self.generate_report
-      if bucket.nil? && (Time.now - self.last_time < LONGEST_WITHOUT_A_REPORT) # and last time is less then 10 minutes...
+      if bucket.nil? && (false && Time.now - self.last_time < LONGEST_WITHOUT_A_REPORT) # and last time is less then 10 minutes...
         Unleash.logger.debug "Report not posted to server, as it would have been empty. (and has been empty for up to 10 min)"
 
         return

--- a/lib/unleash/metrics_reporter.rb
+++ b/lib/unleash/metrics_reporter.rb
@@ -32,7 +32,7 @@ module Unleash
       Unleash.logger.debug "post() Report"
 
       bucket = self.generate_report
-      if bucket.nil? && (false && Time.now - self.last_time < LONGEST_WITHOUT_A_REPORT) # and last time is less then 10 minutes...
+      if bucket.nil? && !(Time.now - self.last_time < LONGEST_WITHOUT_A_REPORT) # and last time is less then 10 minutes...
         Unleash.logger.debug "Report not posted to server, as it would have been empty. (and has been empty for up to 10 min)"
 
         return

--- a/spec/unleash/metrics_reporter_spec.rb
+++ b/spec/unleash/metrics_reporter_spec.rb
@@ -60,6 +60,19 @@ RSpec.describe Unleash::MetricsReporter do
     )
   end
 
+  it "generates the correct report with no metrics" do
+    Unleash.configure do |config|
+      config.url      = 'http://test-url/'
+      config.app_name = 'my-test-app'
+      config.instance_id = 'rspec/test'
+      config.disable_client = true
+    end
+    Unleash.engine = YggdrasilEngine.new
+
+    report = metrics_reporter.generate_report
+    expect(report).to be_nil
+  end
+
   it "sends the correct report" do
     WebMock.stub_request(:post, "http://test-url/client/metrics")
       .with(


### PR DESCRIPTION
## About the changes
This just test that  when `Time.now - self.last_time < LONGEST_WITHOUT_A_REPORT` is false ruby fails to send metrics