### PR TITLE
Handle empty metrics after 10 min

### DIFF
--- a/README.md
+++ b/README.md
@@ -534,7 +534,7 @@ end
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies.
-Then, run `rake spec` to run the tests.
+Then, run `bundle exec rake spec` to run the tests.
 You can also run `bin/console` for an interactive prompt that will allow you to experiment.
 
 This SDK is also built against the Unleash Client Specification tests.
@@ -542,7 +542,7 @@ To run the Ruby SDK against this test suite, you'll need to have a copy on your 
 
 `git clone --branch v$(ruby echo_client_spec_version.rb) https://github.com/Unleash/client-specification.git`
 
-After doing this, `rake spec` will also run the client specification tests.
+After doing this, `bundle exec rake spec` will also run the client specification tests.
 
 To install this gem onto your local machine, run `bundle exec rake install`.
 

--- a/lib/unleash/metrics_reporter.rb
+++ b/lib/unleash/metrics_reporter.rb
@@ -32,7 +32,7 @@ module Unleash
       Unleash.logger.debug "post() Report"
 
       bucket = self.generate_report
-      if bucket.nil? && !(Time.now - self.last_time < LONGEST_WITHOUT_A_REPORT) # and last time is less then 10 minutes...
+      if bucket.nil? && (Time.now - self.last_time >= LONGEST_WITHOUT_A_REPORT) # and last time is less then 10 minutes...
         Unleash.logger.debug "Report not posted to server, as it would have been empty. (and has been empty for up to 10 min)"
 
         return

--- a/lib/unleash/metrics_reporter.rb
+++ b/lib/unleash/metrics_reporter.rb
@@ -31,7 +31,7 @@ module Unleash
       Unleash.logger.debug "post() Report"
 
       report = self.generate_report
-      
+
       if report[:bucket].empty? && (Time.now - self.last_time < LONGEST_WITHOUT_A_REPORT) # and last time is less then 10 minutes...
         Unleash.logger.debug "Report not posted to server, as it would have been empty. (and has been empty for up to 10 min)"
         return

--- a/lib/unleash/metrics_reporter.rb
+++ b/lib/unleash/metrics_reporter.rb
@@ -29,7 +29,9 @@ module Unleash
 
     def post
       Unleash.logger.debug "post() Report"
+
       report = self.generate_report
+      
       if report[:bucket].empty? && (Time.now - self.last_time < LONGEST_WITHOUT_A_REPORT) # and last time is less then 10 minutes...
         Unleash.logger.debug "Report not posted to server, as it would have been empty. (and has been empty for up to 10 min)"
         return

--- a/lib/unleash/metrics_reporter.rb
+++ b/lib/unleash/metrics_reporter.rb
@@ -32,7 +32,7 @@ module Unleash
       Unleash.logger.debug "post() Report"
 
       bucket = self.generate_report
-      if bucket.nil? && (Time.now - self.last_time < LONGEST_WITHOUT_A_REPORT) # and last time is less then 10 minutes...
+      if bucket.nil? && (false && Time.now - self.last_time < LONGEST_WITHOUT_A_REPORT) # and last time is less then 10 minutes...
         Unleash.logger.debug "Report not posted to server, as it would have been empty. (and has been empty for up to 10 min)"
 
         return

--- a/lib/unleash/metrics_reporter.rb
+++ b/lib/unleash/metrics_reporter.rb
@@ -15,7 +15,6 @@ module Unleash
 
     def generate_report
       metrics = Unleash&.engine&.get_metrics()
-      return nil if metrics.nil? || metrics.empty?
 
       {
         'platformName': RUBY_ENGINE,
@@ -24,21 +23,19 @@ module Unleash
         'specVersion': Unleash::CLIENT_SPECIFICATION_VERSION,
         'appName': Unleash.configuration.app_name,
         'instanceId': Unleash.configuration.instance_id,
-        'bucket': metrics
+        'bucket': metrics || {}
       }
     end
 
     def post
       Unleash.logger.debug "post() Report"
-
-      bucket = self.generate_report
-      if bucket.nil? && (Time.now - self.last_time >= LONGEST_WITHOUT_A_REPORT) # and last time is less then 10 minutes...
+      report = self.generate_report
+      if report[:bucket].empty? && (Time.now - self.last_time < LONGEST_WITHOUT_A_REPORT) # and last time is less then 10 minutes...
         Unleash.logger.debug "Report not posted to server, as it would have been empty. (and has been empty for up to 10 min)"
-
         return
       end
 
-      response = Unleash::Util::Http.post(Unleash.configuration.client_metrics_uri, bucket.to_json)
+      response = Unleash::Util::Http.post(Unleash.configuration.client_metrics_uri, report.to_json)
 
       if ['200', '202'].include? response.code
         Unleash.logger.debug "Report sent to unleash server successfully. Server responded with http code #{response.code}"

--- a/lib/unleash/metrics_reporter.rb
+++ b/lib/unleash/metrics_reporter.rb
@@ -32,7 +32,7 @@ module Unleash
       Unleash.logger.debug "post() Report"
 
       bucket = self.generate_report
-      if bucket.nil? && (false && Time.now - self.last_time < LONGEST_WITHOUT_A_REPORT) # and last time is less then 10 minutes...
+      if bucket.nil? && !(Time.now - self.last_time < LONGEST_WITHOUT_A_REPORT) # and last time is less then 10 minutes...
         Unleash.logger.debug "Report not posted to server, as it would have been empty. (and has been empty for up to 10 min)"
 
         return

--- a/spec/unleash/metrics_reporter_spec.rb
+++ b/spec/unleash/metrics_reporter_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe Unleash::MetricsReporter do
     # Do not test the scheduled calls from client/metrics:
     Unleash.configuration.disable_client = true
     Unleash.configuration.disable_metrics = true
+    metrics_reporter.last_time = Time.now
   end
 
   it "generates the correct report" do
@@ -58,19 +59,6 @@ RSpec.describe Unleash::MetricsReporter do
         yes: 1
       }
     )
-  end
-
-  it "generates the correct report with no metrics" do
-    Unleash.configure do |config|
-      config.url      = 'http://test-url/'
-      config.app_name = 'my-test-app'
-      config.instance_id = 'rspec/test'
-      config.disable_client = true
-    end
-    Unleash.engine = YggdrasilEngine.new
-
-    report = metrics_reporter.generate_report
-    expect(report).to be_nil
   end
 
   it "sends the correct report" do
@@ -123,6 +111,35 @@ RSpec.describe Unleash::MetricsReporter do
     metrics_reporter.post
 
     expect(WebMock).to_not have_requested(:post, 'http://test-url/client/metrics')
+  end
+
+  it "generates an empty report when no metrics after 10 minutes" do
+    WebMock.stub_request(:post, "http://test-url/client/metrics")
+      .to_return(status: 200, body: "", headers: {})
+    Unleash.configure do |config|
+      config.url      = 'http://test-url/'
+      config.app_name = 'my-test-app'
+      config.instance_id = 'rspec/test'
+      config.disable_client = true
+    end
+    Unleash.engine = YggdrasilEngine.new
+
+    metrics_reporter.last_time = Time.now - 601
+    report = metrics_reporter.generate_report
+    expect(report[:bucket]).to be_empty
+
+    metrics_reporter.post
+
+    expect(WebMock).to have_requested(:post, 'http://test-url/client/metrics')
+      .with(
+        body: hash_including(
+          yggdrasilVersion: anything,
+          specVersion: anything,
+          platformName: anything,
+          platformVersion: anything,
+          bucket: {}
+        )
+      )
   end
 
   it "includes metadata in the report" do

--- a/spec/unleash/metrics_reporter_spec.rb
+++ b/spec/unleash/metrics_reporter_spec.rb
@@ -60,6 +60,19 @@ RSpec.describe Unleash::MetricsReporter do
     )
   end
 
+  it "generates the correct report with no metrics" do
+    Unleash.configure do |config|
+      config.url      = 'http://test-url/'
+      config.app_name = 'my-test-app'
+      config.instance_id = 'rspec/test'
+      config.disable_client = true
+    end
+    Unleash.engine = YggdrasilEngine.new
+
+    report = metrics_reporter.generate_report
+    expect(report).to be_nil
+  end
+
   it "sends the correct report" do
     WebMock.stub_request(:post, "http://test-url/client/metrics")
       .with(


### PR DESCRIPTION
## About the changes
This PR adds a test to validate what happens when metrics are empty for more than 10 minutes. This other PR #218 tested that it was actually failing.

We've also validated that nil bucket returns a 400 from Unleash server side so instead we should always fallback to an empty bucket.