### PR TITLE
Allow symbols as flag names

### DIFF
--- a/lib/unleash/client.rb
+++ b/lib/unleash/client.rb
@@ -36,6 +36,7 @@ module Unleash
     # rubocop:enable Metrics/AbcSize
 
     def is_enabled?(feature, context = nil, default_value_param = false, &fallback_blk)
+      feature = feature.to_s
       Unleash.logger.debug "Unleash::Client.is_enabled? feature: #{feature} with context #{context}"
 
       default_value = if block_given?
@@ -76,6 +77,7 @@ module Unleash
     end
 
     def get_variant(feature, context = Unleash::Context.new, fallback_variant = disabled_variant)
+      feature = feature.to_s
       variant = Unleash.engine.get_variant(feature, context)
 
       if variant.nil?

--- a/spec/unleash/client_spec.rb
+++ b/spec/unleash/client_spec.rb
@@ -541,6 +541,78 @@ RSpec.describe Unleash::Client do
     expect(unleash_client.disabled?('any_feature', {}, false)).to eq(false)
   end
 
+  it "should accept symbols as flag names", focus: true do
+    WebMock.stub_request(:post, "http://test-url/client/register")
+      .with(
+        headers: {
+          'Accept' => '*/*',
+          'Content-Type' => 'application/json',
+          'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+          'Unleash-Appname' => 'my-test-app',
+          'Unleash-Instanceid' => 'rspec/test',
+          'User-Agent' => "UnleashClientRuby/#{Unleash::VERSION} #{RUBY_ENGINE}/#{RUBY_VERSION} [#{RUBY_PLATFORM}]",
+          'X-Api-Key' => '123'
+        }
+      )
+      .to_return(status: 200, body: "", headers: {})
+
+    features_response_body = '{
+      "version": 1,
+      "features": [
+        "name": "toggleNameAgain",
+        "enabled": true,
+        "strategies": [{ "name": "default" }],
+        "variants": [
+          {
+            "name": "a",
+            "weight": 50,
+            "payload": {
+              "type": "string",
+              "value": ""
+            }
+          },
+          {
+            "name": "b",
+            "weight": 50,
+            "payload": {
+              "type": "string",
+              "value": ""
+            }
+          }
+        ]
+      ]
+    }'
+
+    WebMock.stub_request(:get, "http://test-url/client/features")
+      .with(
+        headers: {
+          'Accept' => '*/*',
+          'Content-Type' => 'application/json',
+          'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+          'Unleash-Appname' => 'my-test-app',
+          'Unleash-Instanceid' => 'rspec/test',
+          'User-Agent' => "UnleashClientRuby/#{Unleash::VERSION} #{RUBY_ENGINE}/#{RUBY_VERSION} [#{RUBY_PLATFORM}]",
+          'X-Api-Key' => '123'
+        }
+      )
+      .to_return(status: 200, body: features_response_body, headers: {})
+
+    Unleash.configure do |config|
+      config.url      = 'http://test-url/'
+      config.app_name = 'my-test-app'
+      config.instance_id = 'rspec/test'
+      config.disable_metrics = true
+      config.custom_http_headers = { 'X-API-KEY' => '123' }
+      config.log_level = Logger::DEBUG
+    end
+
+    unleash_client = Unleash::Client.new
+
+    expect(
+      unleash_client.is_enabled?(:toggleNameAgain, {}, true)
+    ).to eq(true)
+  end
+
   it "should yield correctly to block when using if_enabled" do
     unleash_client = Unleash::Client.new
     cont = Unleash::Context.new(user_id: 1)
@@ -636,6 +708,11 @@ RSpec.describe Unleash::Client do
 
     it 'returns variant' do
       ret = client.get_variant(feature)
+      expect(ret.name).to eq 'a'
+    end
+
+    it 'returns variant with symbolised name' do
+      ret = client.get_variant(feature.to_sym)
       expect(ret.name).to eq 'a'
     end
 


### PR DESCRIPTION
## About the changes

This PR allows developers to specify flag names as symbols. Ruby developers will often use symbols instead of flag names.

## Discussion points

If this PR is not accepted it would be useful to have some sort of clear error at runtime. Today the lib will raise `TypeError: no implicit conversion of Symbol into String` this is not super useful to the developer.