### PR TITLE
chore: bump client spec to 5.1.9

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -27,6 +27,7 @@ jobs:
         os:
           - ubuntu
           - macos
+          - windows
         ruby-version:
           - jruby-9.4
           - 3.3

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -49,11 +49,13 @@ jobs:
         run: bundle install
       - name: Get test project semver
         id: get_semver
+        shell: bash
         run: |
           semver=$(ruby echo_client_spec_version.rb)
           echo "::set-output name=semver::$semver"
       - name: Download test cases
         run: git clone --depth 5 --branch v${{ steps.get_semver.outputs.semver }} https://github.com/Unleash/client-specification.git client-specification
+        shell: bash
       - name: Run tests
         run: bundle exec rake
         env:

--- a/lib/unleash/spec_version.rb
+++ b/lib/unleash/spec_version.rb
@@ -1,3 +1,3 @@
 module Unleash
-  CLIENT_SPECIFICATION_VERSION = "5.1.7".freeze
+  CLIENT_SPECIFICATION_VERSION = "5.1.9".freeze
 end

--- a/spec/unleash/client_specification_spec.rb
+++ b/spec/unleash/client_specification_spec.rb
@@ -24,7 +24,8 @@ RSpec.describe Unleash::Client do
 
   JSON.parse(File.read(SPECIFICATION_PATH + '/index.json')).each do |test_file|
     describe "for #{test_file}" do
-      current_test_set = JSON.parse(File.read(SPECIFICATION_PATH + '/' + test_file))
+      ## Encoding is set in this read purely for JRuby. Don't take this out, it'll work locally and then fail on CI
+      current_test_set = JSON.parse(File.read(SPECIFICATION_PATH + '/' + test_file, encoding: 'utf-8'))
       context "with #{current_test_set.fetch('name')} " do
         tests = current_test_set.fetch('tests', [])
         tests.each do |test|

--- a/spec/unleash/configuration_spec.rb
+++ b/spec/unleash/configuration_spec.rb
@@ -146,7 +146,7 @@ RSpec.describe Unleash do
           'X-API-KEY' => '123',
           'UNLEASH-APPNAME' => 'test-app',
           'UNLEASH-INSTANCEID' => config.instance_id,
-          'Unleash-Client-Spec' => '5.1.7',
+          'Unleash-Client-Spec' => '5.1.9',
           'User-Agent' => "UnleashClientRuby/#{Unleash::VERSION} #{RUBY_ENGINE}/#{RUBY_VERSION} [#{RUBY_PLATFORM}]"
         }
       )

--- a/unleash-client.gemspec
+++ b/unleash-client.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
   spec.required_ruby_version = ">= 2.7"
 
-  spec.add_dependency "yggdrasil-engine", "~> 0.0.9"
+  spec.add_dependency "yggdrasil-engine", "~> 1.0.1"
 
   spec.add_development_dependency "bundler", "~> 2.1"
   spec.add_development_dependency "rake", "~> 12.3"


### PR DESCRIPTION
Bumps client spec to 5.1.9 so we can confirm unicode characters work with Yggdrasil on Windows