### PR TITLE
chore: add ruby 3.4 support in gh actions

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -29,6 +29,7 @@ jobs:
           - macos
         ruby-version:
           - jruby-9.4
+          - 3.4
           - 3.3
           - 3.2
           - 3.1

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Ruby client for the [Unleash](https://github.com/Unleash/unleash) feature manage
 
 ## Supported Ruby interpreters
 
+- MRI 3.4
 - MRI 3.3
 - MRI 3.2
 - MRI 3.1

--- a/unleash-client.gemspec
+++ b/unleash-client.gemspec
@@ -25,6 +25,9 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "yggdrasil-engine", "~> 0.0.9"
 
+  spec.add_dependency "base64", "~> 0.2.0"
+  spec.add_dependency "logger", "~> 1.6.5"
+
   spec.add_development_dependency "bundler", "~> 2.1"
   spec.add_development_dependency "rake", "~> 12.3"
   spec.add_development_dependency "rspec", "~> 3.12"


### PR DESCRIPTION
## About the changes
Add github actions test also in the latest ruby release.