### PR TITLE
feat: client identification headers

### DIFF
--- a/lib/unleash/configuration.rb
+++ b/lib/unleash/configuration.rb
@@ -103,8 +103,7 @@ module Unleash
       self.strategies       = Unleash::Strategies.new
 
       self.custom_http_headers = {}
-
-      @connection_id        = SecureRandom.uuid
+      @connection_id = SecureRandom.uuid
     end
 
     def initialize_default_logger

--- a/lib/unleash/configuration.rb
+++ b/lib/unleash/configuration.rb
@@ -54,6 +54,9 @@ module Unleash
         'User-Agent' => "UnleashClientRuby/#{Unleash::VERSION} #{RUBY_ENGINE}/#{RUBY_VERSION} [#{RUBY_PLATFORM}]",
         'UNLEASH-INSTANCEID' => self.instance_id,
         'UNLEASH-APPNAME' => self.app_name,
+        'X-UNLEASH-APPNAME' => self.app_name,
+        'X-UNLEASH-CONNECTION-ID' => @connection_id,
+        'X-UNLEASH-SDK' => "unleash-ruby@#{Unleash::VERSION}",
         'Unleash-Client-Spec' => CLIENT_SPECIFICATION_VERSION
       }.merge!(generate_custom_http_headers)
     end
@@ -87,6 +90,7 @@ module Unleash
       self.environment      = 'default'
       self.url              = nil
       self.instance_id      = SecureRandom.uuid
+      @connection_id        = SecureRandom.uuid
       self.project_name     = nil
       self.disable_client   = false
       self.disable_metrics  = false

--- a/lib/unleash/configuration.rb
+++ b/lib/unleash/configuration.rb
@@ -90,7 +90,6 @@ module Unleash
       self.environment      = 'default'
       self.url              = nil
       self.instance_id      = SecureRandom.uuid
-      @connection_id        = SecureRandom.uuid
       self.project_name     = nil
       self.disable_client   = false
       self.disable_metrics  = false
@@ -104,6 +103,8 @@ module Unleash
       self.strategies       = Unleash::Strategies.new
 
       self.custom_http_headers = {}
+
+      @connection_id        = SecureRandom.uuid
     end
 
     def initialize_default_logger

--- a/spec/unleash/client_spec.rb
+++ b/spec/unleash/client_spec.rb
@@ -1,3 +1,5 @@
+require "securerandom"
+
 RSpec.describe Unleash::Client do
   after do
     WebMock.reset!
@@ -5,6 +7,9 @@ RSpec.describe Unleash::Client do
   end
 
   it "Uses custom http headers when initializing client" do
+    fixed_uuid = "123e4567-e89b-12d3-a456-426614174000"
+    allow(SecureRandom).to receive(:uuid).and_return(fixed_uuid)
+
     WebMock.stub_request(:post, "http://test-url/client/register")
       .with(
         headers: {
@@ -12,6 +17,7 @@ RSpec.describe Unleash::Client do
           'Content-Type' => 'application/json',
           'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
           'User-Agent' => "UnleashClientRuby/#{Unleash::VERSION} #{RUBY_ENGINE}/#{RUBY_VERSION} [#{RUBY_PLATFORM}]",
+          'X-Unleash-Sdk' => "unleash-ruby@#{Unleash::VERSION}",
           'X-Api-Key' => '123'
         }
       )
@@ -22,7 +28,8 @@ RSpec.describe Unleash::Client do
           'Accept' => '*/*',
           'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
           'Content-Type' => 'application/json',
-          'User-Agent' => "UnleashClientRuby/#{Unleash::VERSION} #{RUBY_ENGINE}/#{RUBY_VERSION} [#{RUBY_PLATFORM}]"
+          'User-Agent' => "UnleashClientRuby/#{Unleash::VERSION} #{RUBY_ENGINE}/#{RUBY_VERSION} [#{RUBY_PLATFORM}]",
+          'X-Unleash-Sdk' => "unleash-ruby@#{Unleash::VERSION}"
         }
       )
       .to_return(status: 200, body: "", headers: {})
@@ -45,8 +52,11 @@ RSpec.describe Unleash::Client do
           'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
           'Content-Type' => 'application/json',
           'Unleash-Appname' => 'my-test-app',
+          'X-Unleash-Appname' => 'my-test-app',
           'Unleash-Instanceid' => 'rspec/test',
+          'X-Unleash-Connection-Id' => fixed_uuid,
           'User-Agent' => "UnleashClientRuby/#{Unleash::VERSION} #{RUBY_ENGINE}/#{RUBY_VERSION} [#{RUBY_PLATFORM}]",
+          'X-Unleash-Sdk' => "unleash-ruby@#{Unleash::VERSION}",
           'X-Api-Key' => '123'
         }
       )
@@ -73,14 +83,18 @@ RSpec.describe Unleash::Client do
       .with(headers: { 'Content-Type': 'application/json' })
       .with(headers: { 'X-API-KEY': '123', 'Content-Type': 'application/json' })
       .with(headers: { 'UNLEASH-APPNAME': 'my-test-app' })
+      .with(headers: { 'X-UNLEASH-APPNAME': 'my-test-app' })
       .with(headers: { 'UNLEASH-INSTANCEID': 'rspec/test' })
+      .with(headers: { 'X-UNLEASH-CONNECTION-ID': fixed_uuid })
     ).to have_been_made.once
 
     expect(
       a_request(:get, "http://test-url/client/features")
       .with(headers: { 'X-API-KEY': '123' })
       .with(headers: { 'UNLEASH-APPNAME': 'my-test-app' })
+      .with(headers: { 'X-UNLEASH-APPNAME': 'my-test-app' })
       .with(headers: { 'UNLEASH-INSTANCEID': 'rspec/test' })
+      .with(headers: { 'X-UNLEASH-CONNECTION-ID': fixed_uuid })
     ).to have_been_made.once
 
     # Test now sending of metrics
@@ -91,7 +105,9 @@ RSpec.describe Unleash::Client do
         .with(headers: { 'Content-Type': 'application/json' })
         .with(headers: { 'X-API-KEY': '123', 'Content-Type': 'application/json' })
         .with(headers: { 'UNLEASH-APPNAME': 'my-test-app' })
+        .with(headers: { 'X-UNLEASH-APPNAME': 'my-test-app' })
         .with(headers: { 'UNLEASH-INSTANCEID': 'rspec/test' })
+        .with(headers: { 'X-UNLEASH-CONNECTION-ID': fixed_uuid })
     ).not_to have_been_made
 
     # Sending metrics, if they have been evaluated:
@@ -103,7 +119,9 @@ RSpec.describe Unleash::Client do
       .with(headers: { 'Content-Type': 'application/json' })
       .with(headers: { 'X-API-KEY': '123', 'Content-Type': 'application/json' })
       .with(headers: { 'UNLEASH-APPNAME': 'my-test-app' })
+      .with(headers: { 'X-UNLEASH-APPNAME': 'my-test-app' })
       .with(headers: { 'UNLEASH-INSTANCEID': 'rspec/test' })
+      .with(headers: { 'X-UNLEASH-CONNECTION-ID': fixed_uuid })
       .with{ |request| JSON.parse(request.body)['bucket']['toggles']['Feature.A']['yes'] == 2 }
     ).to have_been_made.once
   end
@@ -116,8 +134,10 @@ RSpec.describe Unleash::Client do
           'Content-Type' => 'application/json',
           'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
           'Unleash-Appname' => 'my-test-app',
+          'X-Unleash-Appname' => 'my-test-app',
           'Unleash-Instanceid' => 'rspec/test',
           'User-Agent' => "UnleashClientRuby/#{Unleash::VERSION} #{RUBY_ENGINE}/#{RUBY_VERSION} [#{RUBY_PLATFORM}]",
+          'X-Unleash-Sdk' => "unleash-ruby@#{Unleash::VERSION}",
           'X-Api-Key' => '123'
         }
       )
@@ -157,8 +177,10 @@ RSpec.describe Unleash::Client do
           'Content-Type' => 'application/json',
           'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
           'Unleash-Appname' => 'my-test-app',
+          'X-Unleash-Appname' => 'my-test-app',
           'Unleash-Instanceid' => 'rspec/test',
           'User-Agent' => "UnleashClientRuby/#{Unleash::VERSION} #{RUBY_ENGINE}/#{RUBY_VERSION} [#{RUBY_PLATFORM}]",
+          'X-Unleash-Sdk' => "unleash-ruby@#{Unleash::VERSION}",
           'X-Api-Key' => '123'
         }
       )
@@ -257,6 +279,7 @@ RSpec.describe Unleash::Client do
           'Content-Type' => 'application/json',
           'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
           'User-Agent' => "UnleashClientRuby/#{Unleash::VERSION} #{RUBY_ENGINE}/#{RUBY_VERSION} [#{RUBY_PLATFORM}]",
+          'X-Unleash-Sdk' => "unleash-ruby@#{Unleash::VERSION}",
           'X-Api-Key' => '123'
         }
       )
@@ -269,8 +292,10 @@ RSpec.describe Unleash::Client do
           'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
           'Content-Type' => 'application/json',
           'Unleash-Appname' => 'my-test-app',
+          'X-Unleash-Appname' => 'my-test-app',
           'Unleash-Instanceid' => 'rspec/test',
           'User-Agent' => "UnleashClientRuby/#{Unleash::VERSION} #{RUBY_ENGINE}/#{RUBY_VERSION} [#{RUBY_PLATFORM}]",
+          'X-Unleash-Sdk' => "unleash-ruby@#{Unleash::VERSION}",
           'X-Api-Key' => '123'
         }
       )
@@ -305,6 +330,7 @@ RSpec.describe Unleash::Client do
           'Content-Type' => 'application/json',
           'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
           'User-Agent' => "UnleashClientRuby/#{Unleash::VERSION} #{RUBY_ENGINE}/#{RUBY_VERSION} [#{RUBY_PLATFORM}]",
+          'X-Unleash-Sdk' => "unleash-ruby@#{Unleash::VERSION}",
           'X-Api-Key' => '123'
         }
       )
@@ -327,8 +353,10 @@ RSpec.describe Unleash::Client do
           'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
           'Content-Type' => 'application/json',
           'Unleash-Appname' => 'my-test-app',
+          'X-Unleash-Appname' => 'my-test-app',
           'Unleash-Instanceid' => 'rspec/test',
           'User-Agent' => "UnleashClientRuby/#{Unleash::VERSION} #{RUBY_ENGINE}/#{RUBY_VERSION} [#{RUBY_PLATFORM}]",
+          'X-Unleash-Sdk' => "unleash-ruby@#{Unleash::VERSION}",
           'X-Api-Key' => '123'
         }
       )
@@ -605,8 +633,10 @@ RSpec.describe Unleash::Client do
             'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
             'Content-Type' => 'application/json',
             'Unleash-Appname' => 'my-test-app',
+            'X-Unleash-Appname' => 'my-test-app',
             'Unleash-Instanceid' => 'rspec/test',
             'User-Agent' => "UnleashClientRuby/#{Unleash::VERSION} #{RUBY_ENGINE}/#{RUBY_VERSION} [#{RUBY_PLATFORM}]",
+            'X-Unleash-Sdk' => "unleash-ruby@#{Unleash::VERSION}",
             'X-Api-Key' => '123'
           }
         )
@@ -619,8 +649,10 @@ RSpec.describe Unleash::Client do
             'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
             'Content-Type' => 'application/json',
             'Unleash-Appname' => 'my-test-app',
+            'X-Unleash-Appname' => 'my-test-app',
             'Unleash-Instanceid' => 'rspec/test',
             'User-Agent' => "UnleashClientRuby/#{Unleash::VERSION} #{RUBY_ENGINE}/#{RUBY_VERSION} [#{RUBY_PLATFORM}]",
+            'X-Unleash-Sdk' => "unleash-ruby@#{Unleash::VERSION}",
             'X-Api-Key' => '123'
           }
         )

--- a/spec/unleash/configuration_spec.rb
+++ b/spec/unleash/configuration_spec.rb
@@ -1,4 +1,5 @@
 require "unleash/configuration"
+require "securerandom"
 
 RSpec.describe Unleash do
   describe 'Configuration' do
@@ -124,7 +125,9 @@ RSpec.describe Unleash do
       expect{ config.validate! }.not_to raise_error
       expect(config.custom_http_headers).to include({ 'X-API-KEY': '123' })
       expect(config.http_headers).to include({ 'UNLEASH-APPNAME' => 'test-app' })
+      expect(config.http_headers).to include({ 'X-UNLEASH-APPNAME' => 'test-app' })
       expect(config.http_headers).to include('UNLEASH-INSTANCEID')
+      expect(config.http_headers).to include('X-UNLEASH-CONNECTION-ID')
     end
 
     it "should allow lambdas and procs for custom_https_headers via new client" do
@@ -132,6 +135,9 @@ RSpec.describe Unleash do
         { 'X-API-KEY' => '123' }
       end
       allow(custom_headers_proc).to receive(:call).and_call_original
+
+      fixed_uuid = "123e4567-e89b-12d3-a456-426614174000"
+      allow(SecureRandom).to receive(:uuid).and_return(fixed_uuid)
 
       config = Unleash::Configuration.new(
         url: 'https://testurl/api',
@@ -145,7 +151,10 @@ RSpec.describe Unleash do
         {
           'X-API-KEY' => '123',
           'UNLEASH-APPNAME' => 'test-app',
+          'X-UNLEASH-APPNAME' => 'test-app',
           'UNLEASH-INSTANCEID' => config.instance_id,
+          'X-UNLEASH-CONNECTION-ID' => fixed_uuid,
+          'X-UNLEASH-SDK' => "unleash-ruby@#{Unleash::VERSION}",
           'Unleash-Client-Spec' => '5.1.9',
           'User-Agent' => "UnleashClientRuby/#{Unleash::VERSION} #{RUBY_ENGINE}/#{RUBY_VERSION} [#{RUBY_PLATFORM}]"
         }

--- a/spec/unleash/metrics_reporter_spec.rb
+++ b/spec/unleash/metrics_reporter_spec.rb
@@ -69,8 +69,10 @@ RSpec.describe Unleash::MetricsReporter do
           'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
           'Content-Type' => 'application/json',
           'Unleash-Appname' => 'my-test-app',
+          'X-Unleash-Appname' => 'my-test-app',
           'Unleash-Instanceid' => 'rspec/test',
-          'User-Agent' => "UnleashClientRuby/#{Unleash::VERSION} #{RUBY_ENGINE}/#{RUBY_VERSION} [#{RUBY_PLATFORM}]"
+          'User-Agent' => "UnleashClientRuby/#{Unleash::VERSION} #{RUBY_ENGINE}/#{RUBY_VERSION} [#{RUBY_PLATFORM}]",
+          'X-Unleash-Sdk' => "unleash-ruby@#{Unleash::VERSION}"
         }
       )
       .to_return(status: 200, body: "", headers: {})


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes

This PR adds standardised client identification headers to the feature and metrics calls that the client makes to Unleash. The headers are:
- `x-unleash-appname`: the name of the application that is using the client. `UNLEASH-APPNAME` will be deleted in another PR (expand/contract pattern)
- `x-unleash-connection-id`: an internal unique identifier for the current instance of the client generated by the built-in crypto lib
- `x-unleash-sdk`: sdk information in the format `unleash-ruby@<version>` following reference `unleash-node@<version>` naming pattern

All the headers are intended for the Unleash team so clients should not be affected.
The main use cases we have are:
* capacity planning by knowing the number of unique connections made to the backend API
* debugging misconfigured SDKs sending more traffic than expected

Reference implementation: https://github.com/Unleash/unleash-client-node/pull/690

### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
