### PR TITLE
feat: unleash-interval header

### DIFF
--- a/lib/unleash/client.rb
+++ b/lib/unleash/client.rb
@@ -116,6 +116,7 @@ module Unleash
       {
         'appName': Unleash.configuration.app_name,
         'instanceId': Unleash.configuration.instance_id,
+        'connectionId': Unleash.configuration.connection_id,
         'sdkVersion': "unleash-client-ruby:" + Unleash::VERSION,
         'strategies': Unleash.strategies.known_strategies,
         'started': Time.now.iso8601(Unleash::TIME_RESOLUTION),

--- a/lib/unleash/configuration.rb
+++ b/lib/unleash/configuration.rb
@@ -102,7 +102,7 @@ module Unleash
       self.project_name     = nil
       self.disable_client   = false
       self.disable_metrics  = false
-      self.refresh_interval = 10
+      self.refresh_interval = 15
       self.metrics_interval = 60
       self.timeout          = 30
       self.retry_limit      = Float::INFINITY

--- a/lib/unleash/configuration.rb
+++ b/lib/unleash/configuration.rb
@@ -23,6 +23,7 @@ module Unleash
       :bootstrap_config,
       :strategies,
       :use_delta_api
+    attr_reader :connection_id
 
     def initialize(opts = {})
       validate_custom_http_headers!(opts[:custom_http_headers]) if opts.has_key?(:custom_http_headers)

--- a/lib/unleash/metrics_reporter.rb
+++ b/lib/unleash/metrics_reporter.rb
@@ -38,7 +38,7 @@ module Unleash
       end
 
       headers = (Unleash.configuration.http_headers || {}).dup
-      headers.merge!( { 'UNLEASH-INTERVAL' => Unleash.configuration.metrics_interval.to_s })
+      headers.merge!({ 'UNLEASH-INTERVAL' => Unleash.configuration.metrics_interval.to_s })
       response = Unleash::Util::Http.post(Unleash.configuration.client_metrics_uri, report.to_json, headers)
 
       if ['200', '202'].include? response.code

--- a/lib/unleash/metrics_reporter.rb
+++ b/lib/unleash/metrics_reporter.rb
@@ -37,7 +37,9 @@ module Unleash
         return
       end
 
-      response = Unleash::Util::Http.post(Unleash.configuration.client_metrics_uri, report.to_json)
+      headers = (Unleash.configuration.http_headers || {}).dup
+      headers.merge!( { 'UNLEASH-INTERVAL' => Unleash.configuration.metrics_interval.to_s })
+      response = Unleash::Util::Http.post(Unleash.configuration.client_metrics_uri, report.to_json, headers)
 
       if ['200', '202'].include? response.code
         Unleash.logger.debug "Report sent to unleash server successfully. Server responded with http code #{response.code}"

--- a/lib/unleash/metrics_reporter.rb
+++ b/lib/unleash/metrics_reporter.rb
@@ -23,6 +23,7 @@ module Unleash
         'specVersion': Unleash::CLIENT_SPECIFICATION_VERSION,
         'appName': Unleash.configuration.app_name,
         'instanceId': Unleash.configuration.instance_id,
+        'connectionId': Unleash.configuration.connection_id,
         'bucket': metrics || {}
       }
     end

--- a/lib/unleash/toggle_fetcher.rb
+++ b/lib/unleash/toggle_fetcher.rb
@@ -38,7 +38,7 @@ module Unleash
       return if Unleash.configuration.disable_client
 
       headers = (Unleash.configuration.http_headers || {}).dup
-      headers.merge!({'UNLEASH-INTERVAL' => Unleash.configuration.refresh_interval.to_s })
+      headers.merge!({ 'UNLEASH-INTERVAL' => Unleash.configuration.refresh_interval.to_s })
       response = Unleash::Util::Http.get(Unleash.configuration.fetch_toggles_uri, etag, headers)
 
       if response.code == '304'

--- a/lib/unleash/toggle_fetcher.rb
+++ b/lib/unleash/toggle_fetcher.rb
@@ -38,7 +38,7 @@ module Unleash
       return if Unleash.configuration.disable_client
 
       headers = (Unleash.configuration.http_headers || {}).dup
-      headers.merge!( {'UNLEASH-INTERVAL' => Unleash.configuration.refresh_interval.to_s })
+      headers.merge!({'UNLEASH-INTERVAL' => Unleash.configuration.refresh_interval.to_s })
       response = Unleash::Util::Http.get(Unleash.configuration.fetch_toggles_uri, etag, headers)
 
       if response.code == '304'

--- a/lib/unleash/toggle_fetcher.rb
+++ b/lib/unleash/toggle_fetcher.rb
@@ -37,7 +37,9 @@ module Unleash
       Unleash.logger.debug "fetch()"
       return if Unleash.configuration.disable_client
 
-      response = Unleash::Util::Http.get(Unleash.configuration.fetch_toggles_uri, etag)
+      headers = (Unleash.configuration.http_headers || {}).dup
+      headers.merge!( { 'UNLEASH-INTERVAL' => Unleash.configuration.refresh_interval.to_s })
+      response = Unleash::Util::Http.get(Unleash.configuration.fetch_toggles_uri, etag, headers)
 
       if response.code == '304'
         Unleash.logger.debug "No changes according to the unleash server, nothing to do."

--- a/lib/unleash/toggle_fetcher.rb
+++ b/lib/unleash/toggle_fetcher.rb
@@ -38,7 +38,7 @@ module Unleash
       return if Unleash.configuration.disable_client
 
       headers = (Unleash.configuration.http_headers || {}).dup
-      headers.merge!( { 'UNLEASH-INTERVAL' => Unleash.configuration.refresh_interval.to_s })
+      headers.merge!( {'UNLEASH-INTERVAL' => Unleash.configuration.refresh_interval.to_s })
       response = Unleash::Util::Http.get(Unleash.configuration.fetch_toggles_uri, etag, headers)
 
       if response.code == '304'

--- a/lib/unleash/util/http.rb
+++ b/lib/unleash/util/http.rb
@@ -12,10 +12,10 @@ module Unleash
         http.request(request)
       end
 
-      def self.post(uri, body)
+      def self.post(uri, body, headers_override = nil)
         http = http_connection(uri)
 
-        request = Net::HTTP::Post.new(uri.request_uri, http_headers)
+        request = Net::HTTP::Post.new(uri.request_uri, http_headers(nil, headers_override))
         request.body = body
 
         http.request(request)

--- a/spec/unleash/client_spec.rb
+++ b/spec/unleash/client_spec.rb
@@ -279,7 +279,7 @@ RSpec.describe Unleash::Client do
           'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
           'User-Agent' => "UnleashClientRuby/#{Unleash::VERSION} #{RUBY_ENGINE}/#{RUBY_VERSION} [#{RUBY_PLATFORM}]",
           'Unleash-Sdk' => "unleash-client-ruby:#{Unleash::VERSION}",
-          'X-Api-Key' => '123',
+          'X-Api-Key' => '123'
         }
       )
       .to_return(status: 200, body: "", headers: {})

--- a/spec/unleash/client_spec.rb
+++ b/spec/unleash/client_spec.rb
@@ -29,7 +29,8 @@ RSpec.describe Unleash::Client do
           'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
           'Content-Type' => 'application/json',
           'User-Agent' => "UnleashClientRuby/#{Unleash::VERSION} #{RUBY_ENGINE}/#{RUBY_VERSION} [#{RUBY_PLATFORM}]",
-          'Unleash-Sdk' => "unleash-client-ruby:#{Unleash::VERSION}"
+          'Unleash-Sdk' => "unleash-client-ruby:#{Unleash::VERSION}",
+          'Unleash-Interval' => '60'
         }
       )
       .to_return(status: 200, body: "", headers: {})
@@ -56,7 +57,8 @@ RSpec.describe Unleash::Client do
           'Unleash-Connection-Id' => fixed_uuid,
           'User-Agent' => "UnleashClientRuby/#{Unleash::VERSION} #{RUBY_ENGINE}/#{RUBY_VERSION} [#{RUBY_PLATFORM}]",
           'Unleash-Sdk' => "unleash-client-ruby:#{Unleash::VERSION}",
-          'X-Api-Key' => '123'
+          'X-Api-Key' => '123',
+          'Unleash-Interval' => '15'
         }
       )
       .to_return(status: 200, body: simple_features.to_json, headers: {})
@@ -92,6 +94,7 @@ RSpec.describe Unleash::Client do
       .with(headers: { 'UNLEASH-APPNAME': 'my-test-app' })
       .with(headers: { 'UNLEASH-INSTANCEID': 'rspec/test' })
       .with(headers: { 'UNLEASH-CONNECTION-ID': fixed_uuid })
+      .with(headers: { 'UNLEASH-INTERVAL': '15' })
     ).to have_been_made.once
 
     # Test now sending of metrics
@@ -104,6 +107,7 @@ RSpec.describe Unleash::Client do
         .with(headers: { 'UNLEASH-APPNAME': 'my-test-app' })
         .with(headers: { 'UNLEASH-INSTANCEID': 'rspec/test' })
         .with(headers: { 'UNLEASH-CONNECTION-ID': fixed_uuid })
+        .with(headers: { 'UNLEASH-INTERVAL': '60' })
     ).not_to have_been_made
 
     # Sending metrics, if they have been evaluated:
@@ -117,6 +121,7 @@ RSpec.describe Unleash::Client do
       .with(headers: { 'UNLEASH-APPNAME': 'my-test-app' })
       .with(headers: { 'UNLEASH-INSTANCEID': 'rspec/test' })
       .with(headers: { 'UNLEASH-CONNECTION-ID': fixed_uuid })
+      .with(headers: { 'UNLEASH-INTERVAL': '60' })
       .with{ |request| JSON.parse(request.body)['bucket']['toggles']['Feature.A']['yes'] == 2 }
     ).to have_been_made.once
   end
@@ -174,7 +179,8 @@ RSpec.describe Unleash::Client do
           'Unleash-Instanceid' => 'rspec/test',
           'User-Agent' => "UnleashClientRuby/#{Unleash::VERSION} #{RUBY_ENGINE}/#{RUBY_VERSION} [#{RUBY_PLATFORM}]",
           'Unleash-Sdk' => "unleash-client-ruby:#{Unleash::VERSION}",
-          'X-Api-Key' => '123'
+          'X-Api-Key' => '123',
+          'Unleash-Interval' => '15'
         }
       )
       .to_return(status: 200, body: features_response_body, headers: {})
@@ -273,7 +279,7 @@ RSpec.describe Unleash::Client do
           'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
           'User-Agent' => "UnleashClientRuby/#{Unleash::VERSION} #{RUBY_ENGINE}/#{RUBY_VERSION} [#{RUBY_PLATFORM}]",
           'Unleash-Sdk' => "unleash-client-ruby:#{Unleash::VERSION}",
-          'X-Api-Key' => '123'
+          'X-Api-Key' => '123',
         }
       )
       .to_return(status: 200, body: "", headers: {})
@@ -288,7 +294,8 @@ RSpec.describe Unleash::Client do
           'Unleash-Instanceid' => 'rspec/test',
           'User-Agent' => "UnleashClientRuby/#{Unleash::VERSION} #{RUBY_ENGINE}/#{RUBY_VERSION} [#{RUBY_PLATFORM}]",
           'Unleash-Sdk' => "unleash-client-ruby:#{Unleash::VERSION}",
-          'X-Api-Key' => '123'
+          'X-Api-Key' => '123',
+          'Unleash-Interval' => '15'
         }
       )
       .to_return(status: 200, body: "", headers: {})
@@ -348,7 +355,8 @@ RSpec.describe Unleash::Client do
           'Unleash-Instanceid' => 'rspec/test',
           'User-Agent' => "UnleashClientRuby/#{Unleash::VERSION} #{RUBY_ENGINE}/#{RUBY_VERSION} [#{RUBY_PLATFORM}]",
           'Unleash-Sdk' => "unleash-client-ruby:#{Unleash::VERSION}",
-          'X-Api-Key' => '123'
+          'X-Api-Key' => '123',
+          'Unleash-Interval' => '15'
         }
       )
       .to_return(status: 200, body: features_response_body, headers: {})
@@ -642,7 +650,8 @@ RSpec.describe Unleash::Client do
             'Unleash-Instanceid' => 'rspec/test',
             'User-Agent' => "UnleashClientRuby/#{Unleash::VERSION} #{RUBY_ENGINE}/#{RUBY_VERSION} [#{RUBY_PLATFORM}]",
             'Unleash-Sdk' => "unleash-client-ruby:#{Unleash::VERSION}",
-            'X-Api-Key' => '123'
+            'X-Api-Key' => '123',
+            'Unleash-Interval' => '15'
           }
         )
         .to_return(status: 200, body: body, headers: {})

--- a/spec/unleash/configuration_spec.rb
+++ b/spec/unleash/configuration_spec.rb
@@ -213,7 +213,8 @@ RSpec.describe Unleash do
             yggdrasilVersion: anything,
             specVersion: anything,
             platformName: anything,
-            platformVersion: anything
+            platformVersion: anything,
+            connectionId: anything
           )
         )
     end

--- a/spec/unleash/configuration_spec.rb
+++ b/spec/unleash/configuration_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Unleash do
       expect(config.custom_http_headers).to eq({})
       expect(config.disable_metrics).to be_falsey
 
-      expect(config.refresh_interval).to eq(10)
+      expect(config.refresh_interval).to eq(15)
       expect(config.metrics_interval).to eq(60)
       expect(config.timeout).to eq(30)
       expect(config.retry_limit).to eq(Float::INFINITY)

--- a/spec/unleash/metrics_reporter_spec.rb
+++ b/spec/unleash/metrics_reporter_spec.rb
@@ -159,7 +159,8 @@ RSpec.describe Unleash::MetricsReporter do
           yggdrasilVersion: anything,
           specVersion: anything,
           platformName: anything,
-          platformVersion: anything
+          platformVersion: anything,
+          connectionId: anything
         )
       )
   end

--- a/spec/unleash/metrics_reporter_spec.rb
+++ b/spec/unleash/metrics_reporter_spec.rb
@@ -71,7 +71,8 @@ RSpec.describe Unleash::MetricsReporter do
           'Unleash-Appname' => 'my-test-app',
           'Unleash-Instanceid' => 'rspec/test',
           'User-Agent' => "UnleashClientRuby/#{Unleash::VERSION} #{RUBY_ENGINE}/#{RUBY_VERSION} [#{RUBY_PLATFORM}]",
-          'Unleash-Sdk' => "unleash-client-ruby:#{Unleash::VERSION}"
+          'Unleash-Sdk' => "unleash-client-ruby:#{Unleash::VERSION}",
+          'Unleash-Interval' => "60"
         }
       )
       .to_return(status: 200, body: "", headers: {})

--- a/spec/unleash/toggle_fetcher_spec.rb
+++ b/spec/unleash/toggle_fetcher_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe Unleash::ToggleFetcher do
   describe '#fetch!' do
     let(:engine) { YggdrasilEngine.new }
 
-    context 'when fetching toggles succeds' do
+    context 'when fetching toggles succeeds' do
       before do
         _toggle_fetcher = described_class.new engine
       end


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes

* synchronizing `refresh_interval` to be identical to other SDKs (15s for fetch toggles, it was 10s before despite docs claiming it's 15s)
* adding `unleash-interval` header to fetch toggles call and send metric call (they are different so can't share HTTP header setting)
* adding `connectionId` to registration payload and send metrics payload

### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->
Please check toggle_fetcher and metrics_reporter since I added "seams" in those 2 in order to inject different metrics interval headers.

## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
