### PR TITLE
Relax logger dependency

### DIFF
--- a/unleash-client.gemspec
+++ b/unleash-client.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "yggdrasil-engine", "~> 1.0.3"
 
   spec.add_dependency "base64", "~> 0.2.0"
-  spec.add_dependency "logger", "~> 1.6.5"
+  spec.add_dependency "logger", "~> 1.6"
 
   spec.add_development_dependency "bundler", "~> 2.1"
   spec.add_development_dependency "rake", "~> 12.3"


### PR DESCRIPTION
## About the changes
Relax `logger` gem dependency, so unleash can be used with logger >= 1.6.5.

This should allow using unleash gem with [logger 1.7.0](https://github.com/ruby/logger/releases/tag/v1.7.0) (which was released in 26/March).

Tests seem to pass locally.