### PR TITLE
fix: metrics no longer fails after 10 minutes in a loop

### DIFF
--- a/lib/unleash/metrics_reporter.rb
+++ b/lib/unleash/metrics_reporter.rb
@@ -49,12 +49,13 @@ module Unleash
         })
       end
 
+      self.last_time = Time.now
+
       headers = (Unleash.configuration.http_headers || {}).dup
       headers.merge!({ 'UNLEASH-INTERVAL' => Unleash.configuration.metrics_interval.to_s })
       response = Unleash::Util::Http.post(Unleash.configuration.client_metrics_uri, report.to_json, headers)
 
       if ['200', '202'].include? response.code
-        self.last_time = Time.now
         Unleash.logger.debug "Report sent to unleash server successfully. Server responded with http code #{response.code}"
       else
         # :nocov:

--- a/lib/unleash/metrics_reporter.rb
+++ b/lib/unleash/metrics_reporter.rb
@@ -14,7 +14,7 @@ module Unleash
     end
 
     def generate_report
-      metrics = Unleash&.engine&.get_metrics
+      metrics = Unleash.engine&.get_metrics
       return nil if metrics.nil?
 
       generate_report_from_bucket metrics

--- a/spec/unleash/metrics_reporter_spec.rb
+++ b/spec/unleash/metrics_reporter_spec.rb
@@ -128,20 +128,27 @@ RSpec.describe Unleash::MetricsReporter do
 
     metrics_reporter.last_time = Time.now - 601
     report = metrics_reporter.generate_report
-    expect(report[:bucket]).to be_empty
 
     metrics_reporter.post
 
     expect(WebMock).to have_requested(:post, 'http://test-url/client/metrics')
-      .with(
-        body: hash_including(
-          yggdrasilVersion: anything,
-          specVersion: anything,
-          platformName: anything,
-          platformVersion: anything,
-          bucket: {}
+    .with { |req|
+      body = JSON.parse(req.body, symbolize_names: true)
+
+      expect(body).to include(
+        platformName: anything,
+        platformVersion: anything,
+        yggdrasilVersion: anything,
+        specVersion: anything,
+        bucket: include(
+          start: anything,
+          stop: anything,
+          toggles: {}
         )
       )
+
+      true # tell WebMock we're done matching
+    }
   end
 
   it "includes metadata in the report" do

--- a/spec/unleash/metrics_reporter_spec.rb
+++ b/spec/unleash/metrics_reporter_spec.rb
@@ -127,28 +127,28 @@ RSpec.describe Unleash::MetricsReporter do
     Unleash.engine = YggdrasilEngine.new
 
     metrics_reporter.last_time = Time.now - 601
-    report = metrics_reporter.generate_report
+    metrics_reporter.generate_report
 
     metrics_reporter.post
 
-    expect(WebMock).to have_requested(:post, 'http://test-url/client/metrics')
-    .with { |req|
-      body = JSON.parse(req.body, symbolize_names: true)
+    expect(WebMock).to(have_requested(:post, 'http://test-url/client/metrics')
+      .with do |req|
+                         body = JSON.parse(req.body, symbolize_names: true)
 
-      expect(body).to include(
-        platformName: anything,
-        platformVersion: anything,
-        yggdrasilVersion: anything,
-        specVersion: anything,
-        bucket: include(
-          start: anything,
-          stop: anything,
-          toggles: {}
-        )
-      )
+                         expect(body).to include(
+                           platformName: anything,
+                           platformVersion: anything,
+                           yggdrasilVersion: anything,
+                           specVersion: anything,
+                           bucket: include(
+                             start: anything,
+                             stop: anything,
+                             toggles: {}
+                           )
+                         )
 
-      true # tell WebMock we're done matching
-    }
+                         true # tell WebMock we're done matching
+                       end)
   end
 
   it "includes metadata in the report" do


### PR DESCRIPTION
Fixes an issue where the SDK would attempt to report an empty bucket but would send a format that lacked everything Unleash needed to process it and would continue to do that every `metrics_interval` until the SDK received an evaluation for a toggle.

Needs [this](https://github.com/Unleash/unleash-client-ruby/pull/240) to pass