### PR TITLE
chore: update rubocop

### DIFF
--- a/lib/unleash/bootstrap/handler.rb
+++ b/lib/unleash/bootstrap/handler.rb
@@ -15,7 +15,8 @@ module Unleash
         return configuration.data unless self.configuration.data.nil?
         return configuration.block.call if self.configuration.block.is_a?(Proc)
         return Provider::FromFile.read(configuration.file_path) unless self.configuration.file_path.nil?
-        return Provider::FromUrl.read(configuration.url, configuration.url_headers) unless self.configuration.url.nil?
+
+        Provider::FromUrl.read(configuration.url, configuration.url_headers) unless self.configuration.url.nil?
       end
     end
   end

--- a/lib/unleash/context.rb
+++ b/lib/unleash/context.rb
@@ -7,8 +7,8 @@ module Unleash
     def initialize(params = {})
       raise ArgumentError, "Unleash::Context must be initialized with a hash." unless params.is_a?(Hash)
 
-      self.app_name = value_for("appName", params, Unleash&.configuration&.app_name)
-      self.environment = value_for("environment", params, Unleash&.configuration&.environment || "default")
+      self.app_name = value_for("appName", params, Unleash.configuration&.app_name)
+      self.environment = value_for("environment", params, Unleash.configuration&.environment || "default")
       self.user_id = value_for("userId", params)&.to_s
       self.session_id = value_for("sessionId", params)
       self.remote_address = value_for("remoteAddress", params)

--- a/lib/unleash/metrics_reporter.rb
+++ b/lib/unleash/metrics_reporter.rb
@@ -14,7 +14,7 @@ module Unleash
     end
 
     def generate_report
-      metrics = Unleash&.engine&.get_metrics()
+      metrics = Unleash.engine&.get_metrics
 
       {
         'platformName': RUBY_ENGINE,

--- a/unleash-client.gemspec
+++ b/unleash-client.gemspec
@@ -36,7 +36,7 @@ Gem::Specification.new do |spec|
 
   # rubocop:disable Gemspec/RubyVersionGlobalsUsage, Style/IfUnlessModifier
   if Gem::Version.new(RUBY_VERSION) > Gem::Version.new('3.0')
-    spec.add_development_dependency "rubocop", "~> 1.51.0"
+    spec.add_development_dependency "rubocop", "~> 1.75"
   end
   # rubocop:enable Gemspec/RubyVersionGlobalsUsage, Style/IfUnlessModifier
 


### PR DESCRIPTION
CI uses latest and dev is lagging, which gives a very unpleasant surprise when you land your PR on Github and suddenly Rubocop has _**opinions**_

This is just an update to Rubocop 1.75 + apply Rubocop fixes