### PR TITLE
update base64 gem to 0.3.0

### DIFF
--- a/unleash-client.gemspec
+++ b/unleash-client.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "yggdrasil-engine", "~> 1.0.4"
 
-  spec.add_dependency "base64", "~> 0.2.0"
+  spec.add_dependency "base64", "~> 0.3.0"
   spec.add_dependency "logger", "~> 1.6"
 
   spec.add_development_dependency "bundler", "~> 2.1"


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes
Update base64 dependency from v0.2.0 to v0.3.0.

Hello, my project is using unleash-client-ruby on AWS lambda. 
ruby runtime image of AWS lambda was updated and it makes install base64 gem with v0.3.0 into latest ruby3.4 runtime image. 
So, when we use unleash-client-ruby gem with AWS lambda latest runtime image, starting application is fails due to base64 version is conflicted.

So I'd like to update base64 dependency to v0.3.0

  
<!-- Describe the changes introduced. What are they and why are they being introduced? Feel free to also add screenshots or steps to view the changes if they're visual. -->

<!-- Does it close an issue? Multiple? -->


<!-- (For internal contributors): Does it relate to an issue on public roadmap? -->
<!--
Relates to [roadmap](https://github.com/orgs/Unleash/projects/10) item: #
-->

### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->
- unleash-client.gemspec
