### PR TITLE
Updating ld-eventsource and yggdrasil-engine dependencies which require minimal Ruby version 3.1

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,7 +1,7 @@
 # inherit_from: .rubocop_todo.yml
 
 AllCops:
-  TargetRubyVersion: 2.7
+  TargetRubyVersion: 3.1
 
 Naming/PredicateName:
   AllowedMethods:

--- a/unleash-client.gemspec
+++ b/unleash-client.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = ">= 3.1"
 
   spec.add_dependency "ld-eventsource", "~> 2.5.1" unless RUBY_ENGINE == 'jruby'
-  spec.add_dependency "yggdrasil-engine", "~> 1.2.2"
+  spec.add_dependency "yggdrasil-engine", "~> 1.3.0"
 
   spec.add_dependency "base64", "~> 0.3.0"
   spec.add_dependency "logger", "~> 1.6"

--- a/unleash-client.gemspec
+++ b/unleash-client.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
   spec.required_ruby_version = ">= 3.1"
 
-  spec.add_dependency "ld-eventsource", "~> 2.5.1" unless RUBY_ENGINE == 'jruby'
+  spec.add_dependency "ld-eventsource", "~> 2.5" unless RUBY_ENGINE == 'jruby'
   spec.add_dependency "yggdrasil-engine", "~> 1.3.0"
 
   spec.add_dependency "base64", "~> 0.3.0"

--- a/unleash-client.gemspec
+++ b/unleash-client.gemspec
@@ -21,9 +21,9 @@ Gem::Specification.new do |spec|
   spec.bindir        = 'bin'
   spec.executables   = spec.files.grep(%r{^bin/unleash}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
-  spec.required_ruby_version = ">= 2.7"
+  spec.required_ruby_version = ">= 3.1"
 
-  spec.add_dependency "ld-eventsource", "2.2.4" unless RUBY_ENGINE == 'jruby'
+  spec.add_dependency "ld-eventsource", "~> 2.5.1" unless RUBY_ENGINE == 'jruby'
   spec.add_dependency "yggdrasil-engine", "~> 1.2.2"
 
   spec.add_dependency "base64", "~> 0.3.0"
@@ -34,13 +34,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec", "~> 3.12"
   spec.add_development_dependency "rspec-json_expectations", "~> 2.2"
   spec.add_development_dependency "webmock", "~> 3.18.1"
-
-  # rubocop:disable Gemspec/RubyVersionGlobalsUsage, Style/IfUnlessModifier
-  if Gem::Version.new(RUBY_VERSION) > Gem::Version.new('3.0')
-    spec.add_development_dependency "rubocop", "~> 1.75"
-  end
-  # rubocop:enable Gemspec/RubyVersionGlobalsUsage, Style/IfUnlessModifier
-
+  spec.add_development_dependency "rubocop", "~> 1.75"
   spec.add_development_dependency "simplecov", "~> 0.21.2"
   spec.add_development_dependency "simplecov-lcov", "~> 0.8.0"
 end


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes
<!-- Describe the changes introduced. What are they and why are they being introduced? Feel free to also add screenshots or steps to view the changes if they're visual. -->

I updated `ld-eventsource` which was pinned to a fixed version. This change brings a minimal required version of Ruby 3.1.

I took the chance to update as well `yggdrasil-engine` to the latest version which was released recently.

All tests were green for `rspec` and `rubocop`.

## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
I suggest to bump version of Unleash to version 7 since it brings a breaking change for the Ruby version.