### PR TITLE
chore: drop Ruby 2.7 and 3.0

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -36,8 +36,6 @@ jobs:
           - 3.3
           - 3.2
           - 3.1
-          - '3.0'
-          - 2.7
         exclude:
           - os: windows
             ruby-version: jruby-10.0

--- a/README.md
+++ b/README.md
@@ -20,8 +20,6 @@ You can use this client with [Unleash Enterprise](https://www.getunleash.io/pric
 - MRI 3.3
 - MRI 3.2
 - MRI 3.1
-- MRI 3.0
-- MRI 2.7
 - jruby 10.0
 - jruby 9.4
 


### PR DESCRIPTION
These are now going on 3 years EOL and there are two EOL versions that we support after these two. I think that's reasonable legacy support